### PR TITLE
Closes #7: polyglot-go-book-store

### DIFF
--- a/.osmi/agents/implementer/changes.md
+++ b/.osmi/agents/implementer/changes.md
@@ -1,0 +1,13 @@
+# Changes: book-store Cost function
+
+## What was done
+Replaced the `panic` stub in `go/exercises/practice/book-store/book_store.go` with a full implementation of the `Cost` function.
+
+## Implementation details
+- **Greedy grouping**: Count frequency of each book, then greedily form the largest possible groups of distinct books.
+- **5+3 → 4+4 optimization**: Two groups of 4 (2×2560 = 5120) are cheaper than a group of 5 + group of 3 (3000+2160 = 5160). The algorithm swaps paired 5-groups and 3-groups into 4-groups.
+- **Lookup table**: A precomputed `groupCosts` array maps group size → cost in cents.
+
+## Verification
+- `go vet ./...` passes with no issues.
+- All 18 test cases pass.

--- a/go/exercises/practice/book-store/book_store.go
+++ b/go/exercises/practice/book-store/book_store.go
@@ -1,5 +1,73 @@
 package bookstore
 
+var groupCosts = [6]int{
+	0,
+	1 * 800,
+	2 * 800 * 95 / 100,
+	3 * 800 * 90 / 100,
+	4 * 800 * 80 / 100,
+	5 * 800 * 75 / 100,
+}
+
 func Cost(books []int) int {
-	panic("Please implement the Cost function")
+	freq := make(map[int]int)
+	for _, b := range books {
+		freq[b]++
+	}
+
+	counts := make([]int, 0, len(freq))
+	for _, c := range freq {
+		counts = append(counts, c)
+	}
+
+	var groups []int
+	for {
+		size := 0
+		for i := range counts {
+			if counts[i] > 0 {
+				counts[i]--
+				size++
+			}
+		}
+		if size == 0 {
+			break
+		}
+		groups = append(groups, size)
+	}
+
+	fives, threes := 0, 0
+	for _, g := range groups {
+		if g == 5 {
+			fives++
+		}
+		if g == 3 {
+			threes++
+		}
+	}
+	swaps := fives
+	if threes < swaps {
+		swaps = threes
+	}
+	if swaps > 0 {
+		newGroups := make([]int, 0, len(groups))
+		fivesLeft, threesLeft := swaps, swaps
+		for _, g := range groups {
+			if g == 5 && fivesLeft > 0 {
+				newGroups = append(newGroups, 4)
+				fivesLeft--
+			} else if g == 3 && threesLeft > 0 {
+				newGroups = append(newGroups, 4)
+				threesLeft--
+			} else {
+				newGroups = append(newGroups, g)
+			}
+		}
+		groups = newGroups
+	}
+
+	total := 0
+	for _, g := range groups {
+		total += groupCosts[g]
+	}
+	return total
 }


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/7

## osmi Post-Mortem: Issue #7 — polyglot-go-book-store

### Plan Summary
# Implementation Plan: Book Store Cost Function

## Overview

Implement `Cost(books []int) int` in `go/exercises/practice/book-store/book_store.go`. The function must find the optimal grouping of books into sets of distinct titles to minimize total cost after discounts.

## Algorithm Design

### Approach: Frequency-based greedy with 5→3 group splitting optimization

The key insight is that a greedy approach (always forming the largest possible group) fails because two groups of 4 ($25.60 × 2 = $51.20) is cheaper than one group of 5 + one group of 3 ($30.00 + $21.60 = $51.60). The discount jump from 3→4 (10%→20%) is larger than from 4→5 (20%→25%).

**Algorithm:**

1. Count the frequency of each book title in the basket
2. Build groups greedily: repeatedly take one copy of each available distinct title to form groups from largest to smallest
3. Apply the 5+3 → 4+4 optimization: whenever there's a group of 5 and a group of 3, replace them with two groups of 4 (since 2×groupCost(4) < groupCost(5) + groupCost(3))
4. Sum the costs of all groups using the discount tiers

**Why this works:**
- The greedy step produces groups sorted by size (largest first)
- The only suboptimal case in greedy grouping is 5+3 vs 4+4
- All other group size pairs are already optimal under greedy
- The 5+3→4+4 transformation is the only correction needed (confirmed by codex review)

**Discount tiers (per book in group):**
| Group Size | Discount | Per Book | Group Cost |
|------------|----------|----------|------------|
| 1          | 0%       | 800      | 800        |
| 2          | 5%       | 760      | 1520       |
| 3          | 10%      | 720      | 2160       |
| 4          | 20%      | 640      | 2560       |
| 5          | 25%      | 600      | 3000       |

**Verification: 5+3 vs 4+4:**
- 5+3: 3000 + 2160 = 5160
- 4+4: 2560 + 2560 = 5120
- Saving: 40 cents per swap

## File Changes

### Modified: `go/exercises/practice/book-store/book_store.go`

Replace the panic stub with the full implementation:

```go
package bookstore

var groupCosts = [6]int{
    0,

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report

## Checklist

- [x] `go build` passes with no errors — confirmed, clean build with zero output
- [x] All 18 test cases pass — confirmed independently with `go test -v -count=1` (no cache), all 18 sub-tests PASS
- [x] Benchmark runs without errors — confirmed: `BenchmarkCost-128 103362 11048 ns/op 2224 B/op 92 allocs/op`
- [x] `go vet` reports no issues — confirmed, clean output
- [x] Function signature matches `func Cost(books []int) int` — confirmed at `book_store.go:12`
- [x] Package name is `bookstore` — confirmed at `book_store.go:1`
- [x] Only `book_store.go` was modified — confirmed via `git diff --name-only main...HEAD` (only `book_store.go` and `.osmi/agents/implementer/changes.md`)
- [x] All calculations use integer arithmetic (cents) — confirmed: `groupCosts` array uses int constants, all operations are int multiplication/division
- [x] Code compiles with Go 1.18 — confirmed: no `min`/`max` builtins (manual comparison on lines 48-50), no generics, no imports requiring newer Go versions; `go.mod` specifies `go 1.18`

## Verdict: PASS

## Details

### Algorithm
The implementation uses a greedy grouping approach with a 5+3→4+4 optimization:
1. Counts book frequencies
2. Greedily forms groups of maximum distinct books
3. Converts pairs of (5-group, 3-group) into pairs of 4-groups (since 2×4 = $51.20 < 5+3 = $51.60)
4. Sums costs using a precomputed `groupCosts` lookup table

### Code Quality
- Clean, readable implementation at 73 lines
- No external dependencies
- Precomputed cost table avoids repeated arithmetic
- Manual min calculation (`if threes < swaps`) ensures Go 1.18 compatibility

### Test Coverage
All 18 exercism test cases pass, covering:
- Edge cases (empty basket, single book, same books)
- Basic discount groups (2–5 different books)
- Optimization cases where greedy grouping would produce suboptimal results
- Complex baskets with 15+ books


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-7](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-7)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
