### PR TITLE
Closes #11: polyglot-go-bowling

### DIFF
--- a/go/exercises/practice/bowling/bowling.go
+++ b/go/exercises/practice/bowling/bowling.go
@@ -1,15 +1,109 @@
 package bowling
 
-// Define the Game type here.
+import "errors"
 
+// Game tracks the state of a bowling game.
+type Game struct {
+	rolls        []int
+	currentFrame int
+	currentBall  int
+	done         bool
+}
+
+// NewGame creates a new bowling game.
 func NewGame() *Game {
-	panic("Please implement the NewGame function")
+	return &Game{}
 }
 
+// Roll records a roll of the ball knocking down the given number of pins.
 func (g *Game) Roll(pins int) error {
-	panic("Please implement the Roll function")
+	if g.done {
+		return errors.New("cannot roll after game is over")
+	}
+	if pins < 0 {
+		return errors.New("negative roll is invalid")
+	}
+	if pins > 10 {
+		return errors.New("pin count exceeds pins on the lane")
+	}
+
+	if g.currentFrame < 9 {
+		if g.currentBall == 0 {
+			if pins == 10 {
+				g.rolls = append(g.rolls, pins)
+				g.currentFrame++
+			} else {
+				g.rolls = append(g.rolls, pins)
+				g.currentBall = 1
+			}
+		} else {
+			prev := g.rolls[len(g.rolls)-1]
+			if prev+pins > 10 {
+				return errors.New("pin count exceeds pins on the lane")
+			}
+			g.rolls = append(g.rolls, pins)
+			g.currentFrame++
+			g.currentBall = 0
+		}
+	} else {
+		switch g.currentBall {
+		case 0:
+			g.rolls = append(g.rolls, pins)
+			g.currentBall = 1
+		case 1:
+			firstRoll := g.rolls[len(g.rolls)-1]
+			if firstRoll == 10 {
+				// First was a strike, pins reset
+			} else if firstRoll+pins > 10 {
+				return errors.New("pin count exceeds pins on the lane")
+			}
+			g.rolls = append(g.rolls, pins)
+			if firstRoll == 10 || firstRoll+pins == 10 {
+				g.currentBall = 2
+			} else {
+				g.done = true
+			}
+		case 2:
+			firstRoll := g.rolls[len(g.rolls)-2]
+			secondRoll := g.rolls[len(g.rolls)-1]
+			if firstRoll == 10 && secondRoll == 10 {
+				// Two strikes, pins reset
+			} else if firstRoll == 10 {
+				// First was strike, second was not; pins not reset
+				if secondRoll+pins > 10 {
+					return errors.New("pin count exceeds pins on the lane")
+				}
+			}
+			// Spare case: pins reset, 0-10 valid (already checked by top-level)
+			g.rolls = append(g.rolls, pins)
+			g.done = true
+		}
+	}
+
+	return nil
 }
 
+// Score returns the total score for a completed game.
 func (g *Game) Score() (int, error) {
-	panic("Please implement the Score function")
+	if !g.done {
+		return 0, errors.New("score cannot be taken until the end of the game")
+	}
+
+	score := 0
+	rollIndex := 0
+
+	for frame := 0; frame < 10; frame++ {
+		if g.rolls[rollIndex] == 10 {
+			score += 10 + g.rolls[rollIndex+1] + g.rolls[rollIndex+2]
+			rollIndex++
+		} else if g.rolls[rollIndex]+g.rolls[rollIndex+1] == 10 {
+			score += 10 + g.rolls[rollIndex+2]
+			rollIndex += 2
+		} else {
+			score += g.rolls[rollIndex] + g.rolls[rollIndex+1]
+			rollIndex += 2
+		}
+	}
+
+	return score, nil
 }


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/11

## osmi Post-Mortem: Issue #11 — polyglot-go-bowling

### Plan Summary
# Implementation Plan: Go Bowling Exercise

## File to Modify
- `go/exercises/practice/bowling/bowling.go` — the only file that needs changes

## Architecture

### Game Struct Design

```go
type Game struct {
    rolls       []int // all rolls recorded
    currentBall int   // 0 = first ball of frame, 1 = second ball
    currentFrame int  // 0-indexed frame number (0-9)
    done        bool  // game is complete
}
```

The key design decision is to store all rolls in a flat slice and compute the score by walking through the rolls at scoring time, rather than tracking frames explicitly during rolls. This simplifies scoring logic because spare/strike bonuses naturally reference subsequent rolls.

However, we need `currentFrame` and `currentBall` during `Roll()` to validate inputs (e.g., two rolls in a frame can't exceed 10 pins, game-over detection).

### Roll Method Design

`Roll(pins int)` validates and records each roll:

1. **Game over check**: If `done` is true, return error
2. **Basic pin validation**: pins must be 0-10
3. **Frame-aware validation**:
   - **Frames 0-8 (normal frames)**:
     - First ball: pins must be 0-10
     - Second ball: pins + first ball must be <= 10
     - Strike (first ball = 10): advance to next frame immediately
     - Otherwise: advance ball, and if second ball, advance frame
   - **Frame 9 (10th frame)**:
     - First ball: pins must be 0-10
     - Second ball: if first was strike, pins must be 0-10; otherwise first+second <= 10
     - Third ball: depends on first two — if first two are strikes, 0-10; if second was strike after non-strike first, 0-10; if spare (first+second=10), 0-10; otherwise no third ball (but this case means game ended after second ball)
     - After appropriate number of balls, set `done = true`

### 10th Frame Validation Details

The 10th frame is the trickiest part. Tracking:
- `tenthBall` counter (0, 1, 2) within the 10th frame
- After first ball: if strike, pins reset to 10
- After second ball:
  - If first was strike and second is strike: pins reset to 10, allow third
  - If first was strike and second is not strike: remaining = 10 - second, allow third with remaining pins constraint
  - If first + second = 10 (spare): pins reset to 10, allow third
  - If first + second < 10: game over (no bonus)

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: Go Bowling Exercise

## Verdict: PASS

All acceptance criteria have been met. The implementation is correct and complete.

---

## Acceptance Criteria Checklist

### Scoring Tests (21 tests) - ALL PASS

| # | Test Case | Status |
|---|-----------|--------|
| 1 | Score a game with all zeros (0) | PASS |
| 2 | Score a game with no strikes or spares (90) | PASS |
| 3 | A spare followed by zeros (10) | PASS |
| 4 | Points after a spare counted twice (16) | PASS |
| 5 | Consecutive spares each get one roll bonus (31) | PASS |
| 6 | Spare in last frame gets one bonus roll counted once (17) | PASS |
| 7 | A strike earns 10 points in a single-roll frame (10) | PASS |
| 8 | Points after a strike counted twice as bonus (26) | PASS |
| 9 | Consecutive strikes each get two roll bonus (81) | PASS |
| 10 | Strike in last frame gets two bonus rolls counted once (18) | PASS |
| 11 | Rolling a spare with two roll bonus does not get bonus roll (20) | PASS |
| 12 | Strikes with two roll bonus do not get bonus rolls (30) | PASS |
| 13 | Last two strikes followed by non-strike bonus (31) | PASS |
| 14 | Strike with one roll bonus after spare in last frame (20) | PASS |
| 15 | Perfect game (300) | PASS |
| 16 | Two bonus rolls after last-frame strike can score >10 if one is strike (26) | PASS |
| 17 | Unstarted game cannot be scored (error) | PASS |
| 18 | Incomplete game cannot be scored (error) | PASS |
| 19 | Bonus rolls for last-frame strike must be rolled before scoring (error) | PASS |
| 20 | Both bonus rolls for last-frame strike must be rolled (error) | PASS |
| 21 | Bonus roll for last-frame spare must be rolled (error) | PASS |

### Roll Validation Tests (10 tests) - ALL PASS

| # | Test Case | Status |
|---|-----------|--------|
| 1 | Rolls cannot score negative points (error) | PASS |
| 2 | A roll cannot score more than 10 points (error) | PASS |
| 3 | Two rolls in a frame cannot score more than 10 (error) | PASS |
| 4 | Bonus roll after last-frame strike cannot exceed 10 (error) | PASS |
| 5 | Two bonus rolls after last-frame strike cannot exceed 10 (error) | PASS |
| 6 | Second bonus roll cannot be strike if first isn't strike (error) | PASS |
| 7 | Second bonus roll after last-frame strike cannot exceed 10 (error) | PASS |
| 8 | Cannot roll if game already has ten frames (error) | PASS |
| 9 | Cannot roll after bonus roll for spare (error) | PASS |
| 10 | Cannot roll after bonus rolls for strike (error) | PASS |

### Technical Criteria

| Criterion | Status |
|-----------|--------|
| All tests pass with `go test` | PASS (31/31, independently verified) |
| Package name is `bowling` | PASS |
| Module is `bowling` with `go 1.18` | PASS |
| Implementation file is `bowling.go` | PASS |
| `Game` type is defined as a struct | PASS |
| Code follows Go conventions (exported types, error handling) | PASS |
| `NewGame() *Game` constructor implemented | PASS |
| `(g *Game) Roll(pins int) error` method implemented | PASS |
| `(g *Game) Score() (int, error)` method implemented | PASS |

### File Change Constraints

| Constraint | Status |
|-----------|--------|
| Test files not modified | PASS (bowling_test.go, cases_test.go unchanged) |
| go.mod not modified | PASS (module bowling, go 1.18) |
| Only bowling.go changed (exercise files) | PASS (git diff --name-only main shows only bowling.go + .osmi metadata) |

### Challenger Review

- Verdict: NO ISSUES FOUND
- All scoring paths, validation logic, and edge cases traced and verified correct

## Independent Test Run

Tests were independently executed by the verifier with `go test -v -count=1`:
- 31/31 tests passed
- 0 failures
- No build errors


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-11](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-11)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
