### PR TITLE
Closes #63: polyglot-go-book-store

### DIFF
--- a/go/exercises/practice/book-store/book_store.go
+++ b/go/exercises/practice/book-store/book_store.go
@@ -1,1 +1,51 @@
 package bookstore
+
+import "sort"
+
+// Cost calculates the total cost of a basket of books, applying the best possible discount.
+func Cost(books []int) int {
+	if len(books) == 0 {
+		return 0
+	}
+
+	// Count frequency of each book
+	freq := make(map[int]int)
+	for _, b := range books {
+		freq[b]++
+	}
+
+	// Collect and sort frequencies descending
+	counts := make([]int, 0, len(freq))
+	for _, c := range freq {
+		counts = append(counts, c)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(counts)))
+
+	// Build group counts using histogram layer-peeling
+	n := len(counts)
+	groups := make([]int, 6) // groups[i] = number of groups of size i
+	for w := n; w >= 1; w-- {
+		next := 0
+		if w < n {
+			next = counts[w]
+		}
+		groups[w] = counts[w-1] - next
+	}
+
+	// Optimize: convert (5,3) pairs to (4,4) pairs
+	pairs := groups[5]
+	if groups[3] < pairs {
+		pairs = groups[3]
+	}
+	groups[5] -= pairs
+	groups[3] -= pairs
+	groups[4] += 2 * pairs
+
+	// Calculate total cost
+	costTable := [6]int{0, 800, 1520, 2160, 2560, 3000}
+	total := 0
+	for i := 1; i <= 5; i++ {
+		total += groups[i] * costTable[i]
+	}
+	return total
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/63

## osmi Post-Mortem: Issue #63 — polyglot-go-book-store

### Plan Summary
# Implementation Plan: Book Store Cost Function

## File to Modify

- `go/exercises/practice/book-store/book_store.go`

## Algorithm Design

### Approach: Frequency-based Greedy with 5→3 Pair Optimization

The key insight is that a greedy algorithm (always forming the largest possible group) fails because two groups of 4 (cost: 2 × 2560 = 5120) are cheaper than one group of 5 + one group of 3 (cost: 3000 + 2160 = 5160). The difference is 40 cents per such pair.

**Strategy:**

1. Count the frequency of each book title
2. Sort frequencies in descending order to form a histogram
3. Use the frequency histogram to determine group sizes greedily (largest groups first)
4. Apply the 5+3 → 4+4 optimization: for every pair of a group-of-5 and a group-of-3, convert them into two groups-of-4

This approach works because:
- The only non-optimal greedy outcome is groups of 5 paired with groups of 3
- Converting each (5,3) pair to (4,4) saves 40 cents
- All other group-size combinations are already optimal under the greedy approach

### Detailed Steps

1. **Count frequencies**: Create a frequency map of book IDs → count
2. **Build group sizes from histogram**:
   - Sort frequencies descending: e.g., [3, 3, 2, 2, 1]
   - Determine how many groups of each size by computing the differences between sorted frequency levels
   - For frequencies [3,3,2,2,1]: groups at level 1 = 5 books (5-wide), at level 2 = 4 books (4-wide), at level 3 = 2 books (2-wide)
   - This gives: 1 group of 5, 1 group of 4, 1 group of 2
3. **Optimize**: Convert (5,3) pairs to (4,4) pairs
   - Count groups of 5 and groups of 3
   - pairs = min(count_of_5, count_of_3)
   - groups_of_5 -= pairs, groups_of_3 -= pairs, groups_of_4 += 2*pairs
4. **Calculate cost**: Sum up cost for each group size using the discount table

### Discount Table (in cents)
- 1 book: 800 (0% discount)
- 2 books: 1520 (5% discount on 1600)
- 3 books: 2160 (10% discount on 2400)
- 4 books: 2560 (20% discount on 3200)
- 5 books: 3000 (25% discount on 4000)

## Implementation Structure

```go
package bookstore


### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: book-store

## Verdict: **PASS**

## Independent Test Run

All 18 test cases passed when run independently by the verifier:

```
=== RUN   TestCost
=== RUN   TestCost/Only_a_single_book
=== RUN   TestCost/Two_of_the_same_book
=== RUN   TestCost/Empty_basket
=== RUN   TestCost/Two_different_books
=== RUN   TestCost/Three_different_books
=== RUN   TestCost/Four_different_books
=== RUN   TestCost/Five_different_books
=== RUN   TestCost/Two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three
=== RUN   TestCost/Two_groups_of_four_is_cheaper_than_groups_of_five_and_three
=== RUN   TestCost/Group_of_four_plus_group_of_two_is_cheaper_than_two_groups_of_three
=== RUN   TestCost/Two_each_of_first_four_books_and_one_copy_each_of_rest
=== RUN   TestCost/Two_copies_of_each_book
=== RUN   TestCost/Three_copies_of_first_book_and_two_each_of_remaining
=== RUN   TestCost/Three_each_of_first_two_books_and_two_each_of_remaining_books
=== RUN   TestCost/Four_groups_of_four_are_cheaper_than_two_groups_each_of_five_and_three
=== RUN   TestCost/Check_that_groups_of_four_are_created_properly_even_when_there_are_more_groups_of_three_than_groups_of_five
=== RUN   TestCost/One_group_of_one_and_four_is_cheaper_than_one_group_of_two_and_three
=== RUN   TestCost/One_group_of_one_and_two_plus_three_groups_of_four_is_cheaper_than_one_group_of_each_size
--- PASS: TestCost (0.00s)
PASS
ok  	bookstore	(cached)
```

## Benchmark

```
BenchmarkCost-128     	  112760	     11140 ns/op
PASS
ok  	bookstore	1.376s
```

## Acceptance Criteria Checklist

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All 18 test cases pass | PASS |
| 2 | Benchmark runs without error | PASS |
| 3 | Function signature is `func Cost(books []int) int` | PASS |
| 4 | Package name is `bookstore` | PASS |
| 5 | File is `book_store.go` | PASS |
| 6 | Only integer arithmetic used (no floating point) | PASS |

## Code Review Notes

- The implementation uses a histogram layer-peeling approach to determine group sizes, then optimizes by converting (5,3) group pairs to (4,4) pairs (since 2*2560 = 5120 < 3000+2160 = 5160).
- All cost values are stored as integer cents in `[6]int{0, 800, 1520, 2160, 2560, 3000}`.
- No `float32`, `float64`, or decimal literal appears anywhere in the code.
- The solution correctly handles the non-greedy optimization cases.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-63](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-63)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
