### PR TITLE
Closes #77: polyglot-go-bowling

### DIFF
--- a/go/exercises/practice/bowling/bowling.go
+++ b/go/exercises/practice/bowling/bowling.go
@@ -1,1 +1,131 @@
+// Package bowling implements scoring for the game of bowling.
 package bowling
+
+import "errors"
+
+var (
+	ErrNegativeRollIsInvalid        = errors.New("Negative roll is invalid")
+	ErrPinCountExceedsPinsOnTheLane = errors.New("Pin count exceeds pins on the lane")
+	ErrPrematureScore               = errors.New("Score cannot be taken until the end of the game")
+	ErrCannotRollAfterGameOver      = errors.New("Cannot roll after game is over")
+)
+
+const (
+	pinsPerFrame      = 10
+	framesPerGame     = 10
+	maxRollsPerFrame  = 2
+	maxRollsLastFrame = 3
+	maxRolls          = (maxRollsPerFrame * (framesPerGame - 1)) + maxRollsLastFrame
+)
+
+// Game records the data to track a game's progress.
+type Game struct {
+	rolls       [maxRolls]int // storage for the rolls
+	nRolls      int           // counts the rolls accumulated.
+	nFrames     int           // counts completed frames, up to framesPerGame.
+	rFrameStart int           // tracks the starting roll of each frame.
+}
+
+// NewGame returns a fresh zero-valued game struct.
+func NewGame() *Game {
+	return &Game{}
+}
+
+// Roll records one roll for a bowling frame with 'pins' knocked down.
+// An error is possible depending on pin value and previous rolls.
+func (g *Game) Roll(pins int) error {
+	if pins > pinsPerFrame {
+		return ErrPinCountExceedsPinsOnTheLane
+	}
+	if pins < 0 {
+		return ErrNegativeRollIsInvalid
+	}
+	if g.completedFrames() == framesPerGame {
+		return ErrCannotRollAfterGameOver
+	}
+	// Record the roll.
+	g.rolls[g.nRolls] = pins
+	g.nRolls++
+	if pins == pinsPerFrame && g.completedFrames() < framesPerGame-1 {
+		// Frames before last one can be strikes with no problems.
+		g.completeTheFrame()
+		return nil
+	}
+	if g.rollsThisFrame() == maxRollsPerFrame {
+		// Have counted normal max rolls on a frame.
+		if g.rawFrameScore(g.rFrameStart) > pinsPerFrame {
+			// Unless we have completed all but last frame, cannot count > pinsPerFrame.
+			if g.completedFrames() != framesPerGame-1 || !g.isStrike(g.rFrameStart) {
+				return ErrPinCountExceedsPinsOnTheLane
+			}
+		}
+		if g.completedFrames() < framesPerGame-1 {
+			// Completed frames before last one with maxRollsPerFrame.
+			g.completeTheFrame()
+			return nil
+		}
+		// For last frame, is it complete now?
+		if g.rawFrameScore(g.rFrameStart) < pinsPerFrame {
+			// Yes, complete.
+			g.completeTheFrame()
+		}
+	} else if g.rollsThisFrame() == maxRollsLastFrame {
+		// Extra roll on the last frame.
+		if g.isStrike(g.rFrameStart) {
+			// First was a strike.
+			if !g.isStrike(g.rFrameStart + 1) {
+				// Second was NOT a strike, so last 2 rolls cannot exceed pinsPerFrame.
+				if g.strikeBonus(g.rFrameStart) > pinsPerFrame {
+					return ErrPinCountExceedsPinsOnTheLane
+				}
+			}
+			if b := g.strikeBonus(g.rFrameStart); b > pinsPerFrame && b < 2*pinsPerFrame {
+				// Unless one of the bonuses was a strike, bonus frames too high.
+				if !g.isStrike(g.rFrameStart+1) && !g.isStrike(g.rFrameStart+2) {
+					return ErrPinCountExceedsPinsOnTheLane
+				}
+			}
+		} else if !g.isSpare(g.rFrameStart) {
+			// Attempt to make extra roll in last frame without strike or spare.
+			return ErrCannotRollAfterGameOver
+		}
+		// Completed last frame.
+		g.completeTheFrame()
+	}
+
+	return nil
+}
+
+// Score returns the score of the game with a potential error.
+func (g *Game) Score() (int, error) {
+	if g.completedFrames() != framesPerGame {
+		return 0, ErrPrematureScore
+	}
+
+	score := 0
+	frameStart := 0
+
+	for frame := 0; frame < framesPerGame; frame++ {
+		switch {
+		case g.isStrike(frameStart):
+			score += pinsPerFrame + g.strikeBonus(frameStart)
+			frameStart++
+		case g.isSpare(frameStart):
+			score += pinsPerFrame + g.spareBonus(frameStart)
+			frameStart += maxRollsPerFrame
+		default:
+			score += g.rawFrameScore(frameStart)
+			frameStart += maxRollsPerFrame
+		}
+	}
+	return score, nil
+}
+
+func (g *Game) rollsThisFrame() int     { return g.nRolls - g.rFrameStart }
+func (g *Game) completeTheFrame()       { g.nFrames++; g.rFrameStart = g.nRolls }
+func (g *Game) completedFrames() int    { return g.nFrames }
+func (g *Game) isStrike(f int) bool     { return g.rolls[f] == pinsPerFrame }
+func (g *Game) rawFrameScore(f int) int { return g.rolls[f] + g.rolls[f+1] }
+func (g *Game) spareBonus(f int) int    { return g.rolls[f+2] }
+func (g *Game) strikeBonus(f int) int   { return g.rolls[f+1] + g.rolls[f+2] }
+func (g *Game) isSpare(f int) bool      { return (g.rolls[f] + g.rolls[f+1]) == pinsPerFrame }


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/77

## osmi Post-Mortem: Issue #77 — polyglot-go-bowling

### Plan Summary
# Implementation Plan: Bowling Game Scoring

## Overview

Replace the stub in `go/exercises/practice/bowling/bowling.go` with a complete bowling game scorer implementation. The solution uses an array-based roll storage approach with frame completion tracking for validation and score calculation.

## Architecture

### Data Model

```go
type Game struct {
    rolls       [23]int  // max possible rolls: 9 frames * 2 + 3 (10th frame) = 21, but 23 for safe indexing
    nRolls      int      // number of rolls recorded so far
    nFrames     int      // number of completed frames (0-10)
    rFrameStart int      // index into rolls[] where current frame begins
}
```

**Rationale**: Store raw rolls in a flat array rather than a frame-based structure. This simplifies bonus calculation (just index forward from the frame start) and matches how scoring naturally works — you need to look ahead for strike/spare bonuses.

### API Design

1. **`NewGame() *Game`** — Returns zero-valued Game (all fields default to 0, which is correct initial state)

2. **`Roll(pins int) error`** — Validates and records a roll:
   - Validate: pins >= 0, pins <= 10
   - Validate: game not over (completed frames < 10)
   - Record the roll
   - Determine frame completion based on game state
   - For frames 1-9: strike completes immediately; two rolls complete the frame (validate sum <= 10)
   - For frame 10: special handling for bonus rolls after strike/spare

3. **`Score() (int, error)`** — Calculate total score:
   - Validate: game is complete (10 frames)
   - Iterate through frames 1-9, applying strike/spare bonuses
   - Frame 10 scored at face value (bonuses already counted in pin totals)

### Error Variables

```go
var (
    ErrNegativeRollIsInvalid        = errors.New("Negative roll is invalid")
    ErrPinCountExceedsPinsOnTheLane = errors.New("Pin count exceeds pins on the lane")
    ErrPrematureScore               = errors.New("Score cannot be taken until the end of the game")
    ErrCannotRollAfterGameOver      = errors.New("Cannot roll after game is over")
)
```

### Roll Validation Logic (Frame 10)

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report

## Verdict: PASS

## Independent Verification

All checks below were run independently by the verifier agent.

## Acceptance Criteria Check

| Criterion | Status | Details |
|-----------|--------|---------|
| All 16 score test cases pass | PASS | 16/16 score calculation tests passed |
| All incomplete game cases return errors | PASS | 5/5 error cases passed (unstarted, incomplete, 2x strike bonus pending, spare bonus pending) |
| All roll validation cases pass | PASS | 10/10 roll validation tests passed |
| Code compiles | PASS | `go build ./...` succeeds with no errors |
| All tests pass | PASS | 31/31 tests pass (`go test -v ./...`) |
| No new dependencies | PASS | go.mod: only `module bowling` + `go 1.18`, imports only `errors` from stdlib |

## Detailed Verification

### Build Verification
- `go build ./...` completed with zero errors
- No warnings or compilation issues

### Score Tests (16/16 passed)
- should be able to score a game with all zeros (= 0)
- should be able to score a game with no strikes or spares (= 90)
- a spare followed by zeros is worth ten points (= 10)
- points scored in the roll after a spare are counted twice (= 16)
- consecutive spares each get a one roll bonus (= 31)
- a spare in the last frame gets a one roll bonus that is counted once (= 17)
- a strike earns ten points in a frame with a single roll (= 10)
- points scored in the two rolls after a strike are counted twice as a bonus (= 26)
- consecutive strikes each get the two roll bonus (= 81)
- a strike in the last frame gets a two roll bonus that is counted once (= 18)
- rolling a spare with the two roll bonus does not get a bonus roll (= 20)
- strikes with the two roll bonus do not get bonus rolls (= 30)
- last two strikes followed by only last bonus with non strike points (= 31)
- a strike with the one roll bonus after a spare in the last frame does not get a bonus (= 20)
- all strikes is a perfect game (= 300)
- two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike (= 26)

### Incomplete Game Error Tests (5/5 passed)
- an unstarted game cannot be scored
- an incomplete game cannot be scored
- bonus rolls for a strike in the last frame must be rolled before score can be calculated
- both bonus rolls for a strike in the last frame must be rolled before score can be calculated
- bonus roll for a spare in the last frame must be rolled before score can be calculated

### Roll Validation Tests (10/10 passed)
- rolls cannot score negative points
- a roll cannot score more than 10 points
- two rolls in a frame cannot score more than 10 points
- bonus roll after a strike in the last frame cannot score more than 10 points
- two bonus rolls after a strike in the last frame cannot score more than 10 points
- the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike
- second bonus roll after a strike in the last frame cannot score more than 10 points
- cannot roll if game already has ten frames
- cannot roll after bonus roll for spare
- cannot roll after bonus rolls for strike

### Dependency Verification
- go.mod contains no `require` directives
- Only standard library import: `errors`
- Go version: 1.18 (compatible with Go 1.18+)

### Code Structure Verification
- Package name: `bowling` (correct)
- Exports: `Game` struct, `NewGame()`, `Roll()`, `Score()` (all present)
- Test files: `bowling_test.go` and `cases_test.go` (unmodified)
- Solution contained in `bowling.go` only

## Conclusion

All acceptance criteria from GOAL.md are met. The implementation is complete, correct, and all 31 tests pass. Independent verification confirms the executor's test results.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-77](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-77)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
