### PR TITLE
Closes #82: polyglot-go-beer-song

### DIFF
--- a/.osmi/agents/implementer/changes.md
+++ b/.osmi/agents/implementer/changes.md
@@ -1,0 +1,13 @@
+# Changes: Beer Song Implementation
+
+## Modified Files
+
+### `go/exercises/practice/beer-song/beer_song.go`
+- Replaced stub (`package beer` only) with full implementation
+- Added imports: `bytes`, `fmt`
+- Implemented `Verse(n int) (string, error)`: Returns a single verse for bottle count n (0-99), with special cases for n=0 (no more bottles), n=1 (singular bottle, "Take it down"), n=2 (next bottle is singular), and default (n>=3, uses fmt.Sprintf)
+- Implemented `Verses(start, stop int) (string, error)`: Returns verses from start down to stop, validates ranges and ordering, uses bytes.Buffer for efficient concatenation
+- Implemented `Song() string`: Returns the full song by calling `Verses(99, 0)`
+
+## Test Results
+All tests pass: `TestBottlesVerse` (6 subtests), `TestSeveralVerses` (5 subtests), `TestEntireSong`

--- a/go/exercises/practice/beer-song/beer_song.go
+++ b/go/exercises/practice/beer-song/beer_song.go
@@ -1,1 +1,54 @@
 package beer
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Song returns the full lyrics for 99 bottles of beer
+func Song() (result string) {
+	result, _ = Verses(99, 0)
+	return
+}
+
+// Verses returns an excerpt of the lyrics of 99 bottles of beer
+// between verse start and stop. The verse numbers count backwards, so the
+// first verse sung will be verse 99, and the last will be verse 0
+func Verses(start, stop int) (string, error) {
+	switch {
+	case 0 > start || start > 99:
+		return "", fmt.Errorf("start value[%d] is not a valid verse", start)
+	case 0 > stop || stop > 99:
+		return "", fmt.Errorf("stop value[%d] is not a valid verse", stop)
+	case start < stop:
+		return "", fmt.Errorf("start value[%d] is less than stop value[%d]", start, stop)
+	}
+
+	var buff bytes.Buffer
+	for i := start; i >= stop; i-- {
+		v, _ := Verse(i)
+		buff.WriteString(v)
+		buff.WriteString("\n")
+	}
+	return buff.String(), nil
+}
+
+// Verse returns a single verse of the lyrics of 99 bottles of beer. The verse
+// numbers count backwards, so the first verse sung will be verse 99, and the
+// last will be verse 0
+func Verse(n int) (string, error) {
+	result := ""
+	switch {
+	case 0 > n || n > 99:
+		return "", fmt.Errorf("%d is not a valid verse", n)
+	case n == 0:
+		result = "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n"
+	case n == 1:
+		result = "1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n"
+	case n == 2:
+		result = "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n"
+	default:
+		result = fmt.Sprintf("%d bottles of beer on the wall, %d bottles of beer.\nTake one down and pass it around, %d bottles of beer on the wall.\n", n, n, n-1)
+	}
+	return result, nil
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/82

## osmi Post-Mortem: Issue #82 — polyglot-go-beer-song

### Plan Summary
# Implementation Plan: Beer Song (Issue #82)

## Overview

Implement three exported functions (`Verse`, `Verses`, `Song`) in `go/exercises/practice/beer-song/beer_song.go` to generate the lyrics for "99 Bottles of Beer on the Wall".

## File to Modify

**`go/exercises/practice/beer-song/beer_song.go`** — Replace the stub (currently only `package beer`) with the full implementation.

No other files need to be created or modified.

## Architectural Decisions

1. **Single file implementation** — All three functions in one file, following the pattern of other exercises in this repo.
2. **Switch-based verse generation** — Use a `switch` statement in `Verse()` with cases for n=0, n=1, n=2, and default (n>=3). This balances readability with correctness.
3. **`bytes.Buffer` for multi-verse concatenation** — Use `bytes.Buffer` in `Verses()` for efficient string building.
4. **`fmt` for formatting and errors** — Use `fmt.Sprintf` for the generic verse template and `fmt.Errorf` for error messages.

## Implementation Details

### Imports

```go
import (
    "bytes"
    "fmt"
)
```

### `Verse(n int) (string, error)`

- Validate: `n < 0 || n > 99` → return error
- Switch on n:
  - `n == 0`: Return the "No more bottles" verse (hardcoded string)
  - `n == 1`: Return the "1 bottle" verse (singular, "Take it down", "no more")
  - `n == 2`: Return the "2 bottles" verse (next bottle is singular "1 bottle")
  - `default` (n >= 3): Use `fmt.Sprintf` with `n` and `n-1`

### `Verses(start, stop int) (string, error)`

- Validate start range (0-99), stop range (0-99), start >= stop
- Loop from start down to stop, calling `Verse(i)` for each
- Append each verse to a `bytes.Buffer`, followed by `"\n"` (blank line separator)
- Return `buff.String()`

### `Song() string`

- Call `Verses(99, 0)`, ignore error (guaranteed valid), return result


### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: Beer Song (Issue #82)

## Verdict: PASS

All acceptance criteria have been independently verified.

## Independent Test Results

### Build (`go build ./...`)
- **Result: PASS** — compiles with zero errors, zero warnings

### Unit Tests (`go test -v ./...`)
- **Result: PASS** — 12/12 tests passing

| Test Suite | Tests | Passed | Failed |
|---|---|---|---|
| TestBottlesVerse | 6 | 6 | 0 |
| TestSeveralVerses | 5 | 5 | 0 |
| TestEntireSong | 1 | 1 | 0 |
| **Total** | **12** | **12** | **0** |

### Benchmarks (`go test -bench=. ./...`)
- **Result: PASS** — both benchmarks complete successfully

| Benchmark | Iterations | ns/op |
|---|---|---|
| BenchmarkSeveralVerses-128 | 254,871 | 5,260 |
| BenchmarkEntireSong-128 | 18,812 | 63,092 |

### Static Analysis (`go vet ./...`)
- **Result: PASS** — no issues detected

## Acceptance Criteria Checklist

| # | Criterion | Status | Notes |
|---|---|---|---|
| 1 | All tests in `beer_song_test.go` pass | PASS | 12/12, exit code 0 |
| 2 | `Verse(n)` returns correct lyrics for n=0,1,2,3..99 | PASS | All special cases handled: n>=3 (plural), n==2 (singular next), n==1 ("Take it down", "no more"), n==0 ("No more", "Go to the store") |
| 3 | `Verse(n)` returns error for n<0 or n>99 | PASS | Switch case `0 > n \|\| n > 99` with descriptive error |
| 4 | `Verses(start, stop)` returns correctly formatted multi-verse output | PASS | Blank line separators via `\n` after each verse |
| 5 | `Verses(start, stop)` returns errors for invalid inputs | PASS | Validates start/stop range and start < stop |
| 6 | `Song()` returns the complete song matching `Verses(99, 0)` | PASS | Directly delegates to `Verses(99, 0)` |
| 7 | Code compiles without errors (`go build`) | PASS | Clean build |
| 8 | Benchmarks run without errors | PASS | Both benchmarks complete |

## Implementation Review

- **Package**: `beer` (correct)
- **Module**: `beer` with Go 1.18 (correct)
- **Dependencies**: Only stdlib (`bytes`, `fmt`) — no external deps
- **Code quality**: Clean, idiomatic Go with proper error handling via `fmt.Errorf`
- **Approach**: Switch-based dispatch for special cases, `fmt.Sprintf` for general case, `bytes.Buffer` for verse concatenation

## Conclusion

The implementation fully satisfies all 8 acceptance criteria. Tests, build, benchmarks, and static analysis all pass. The code is clean, correct, and uses only standard library packages.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-82](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-82)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
