### PR TITLE
Closes #86: polyglot-go-beer-song

### DIFF
--- a/go/exercises/practice/beer-song/beer_song.go
+++ b/go/exercises/practice/beer-song/beer_song.go
@@ -1,1 +1,49 @@
 package beer
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Song returns the full lyrics for 99 bottles of beer.
+func Song() string {
+	result, _ := Verses(99, 0)
+	return result
+}
+
+// Verses returns the lyrics from verse start down to verse stop.
+func Verses(start, stop int) (string, error) {
+	if start < 0 || start > 99 {
+		return "", fmt.Errorf("start value[%d] is not a valid verse", start)
+	}
+	if stop < 0 || stop > 99 {
+		return "", fmt.Errorf("stop value[%d] is not a valid verse", stop)
+	}
+	if start < stop {
+		return "", fmt.Errorf("start value[%d] is less than stop value[%d]", start, stop)
+	}
+
+	var buf bytes.Buffer
+	for i := start; i >= stop; i-- {
+		v, _ := Verse(i)
+		buf.WriteString(v)
+		buf.WriteString("\n")
+	}
+	return buf.String(), nil
+}
+
+// Verse returns a single verse of the song.
+func Verse(n int) (string, error) {
+	switch {
+	case n < 0 || n > 99:
+		return "", fmt.Errorf("%d is not a valid verse", n)
+	case n == 0:
+		return "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n", nil
+	case n == 1:
+		return "1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n", nil
+	case n == 2:
+		return "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n", nil
+	default:
+		return fmt.Sprintf("%d bottles of beer on the wall, %d bottles of beer.\nTake one down and pass it around, %d bottles of beer on the wall.\n", n, n, n-1), nil
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/86

## osmi Post-Mortem: Issue #86 — polyglot-go-beer-song

### Plan Summary
# Implementation Plan: Beer Song

## File to Modify

- `go/exercises/practice/beer-song/beer_song.go` — the only file to change

## Approach

Implement three exported functions in the `beer` package:

### 1. `Verse(n int) (string, error)`

Use a switch statement to handle four cases:
- `n < 0 || n > 99`: return error
- `n == 0`: "No more bottles..." / "Go to the store..."
- `n == 1`: "1 bottle..." (singular) / "Take it down..." / "no more bottles"
- `n == 2`: "2 bottles..." / "Take one down..." / "1 bottle" (singular on second line)
- `default` (3-99): standard format with `fmt.Sprintf` using `n` and `n-1`

Each verse is two lines ending with `\n`.

### 2. `Verses(start, stop int) (string, error)`

- Validate: start and stop must be 0-99, start >= stop
- Loop from start down to stop, calling `Verse(i)` for each
- Join verses with an extra `\n` between them (each verse already ends with `\n`, so append `\n` after each)
- Use `strings.Builder` or `bytes.Buffer` for efficiency

### 3. `Song() string`

- Simply call `Verses(99, 0)` and return the result (ignoring error since inputs are known-valid)

## Imports

- `fmt` for Sprintf and Errorf
- `bytes` for Buffer (or `strings` for Builder)

## Order of Changes

1. Write the complete `beer_song.go` with all three functions
2. Run tests to verify


### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
No verification report found.

### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-86](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-86)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
