### PR TITLE
Closes #131: polyglot-go-kindergarten-garden

### DIFF
--- a/go/exercises/practice/kindergarten-garden/kindergarten_garden.go
+++ b/go/exercises/practice/kindergarten-garden/kindergarten_garden.go
@@ -1,1 +1,57 @@
 package kindergarten
+
+import (
+	"errors"
+	"sort"
+	"strings"
+)
+
+type Garden map[string][]string
+
+func (g *Garden) Plants(child string) ([]string, bool) {
+	p, ok := (*g)[child]
+	return p, ok
+}
+
+func NewGarden(diagram string, children []string) (*Garden, error) {
+	rows := strings.Split(diagram, "\n")
+	if len(rows) != 3 || rows[0] != "" {
+		return nil, errors.New("diagram must have two rows")
+	}
+	if len(rows[1]) != len(rows[2]) {
+		return nil, errors.New("diagram rows must be same length")
+	}
+	if len(rows[1]) != 2*len(children) {
+		return nil, errors.New("each diagram row must have two cups per child")
+	}
+	g := Garden{}
+	alpha := append([]string{}, children...)
+	sort.Strings(alpha)
+	for _, n := range alpha {
+		g[n] = make([]string, 0, 4)
+	}
+	if len(g) != len(alpha) {
+		return nil, errors.New("no two children can have the same name")
+	}
+	for _, row := range rows[1:] {
+		for nx, n := range alpha {
+			for cx := range rows[1:] {
+				var p string
+				switch row[2*nx+cx] {
+				case 'G':
+					p = "grass"
+				case 'C':
+					p = "clover"
+				case 'R':
+					p = "radishes"
+				case 'V':
+					p = "violets"
+				default:
+					return nil, errors.New("plant codes must be one of G, C, R, or V")
+				}
+				g[n] = append(g[n], p)
+			}
+		}
+	}
+	return &g, nil
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/131

## osmi Post-Mortem: Issue #131 — polyglot-go-kindergarten-garden

### Plan Summary
# Implementation Plan: Kindergarten Garden

## File to Modify

- `go/exercises/practice/kindergarten-garden/kindergarten_garden.go`

No other files need to be created or modified.

## Architecture

### Type Definition

```go
type Garden map[string][]string
```

`Garden` is a type alias for `map[string][]string`, mapping child names to their list of 4 plant names. This allows the `Plants` method to do a simple map lookup.

### Plants Method

```go
func (g *Garden) Plants(child string) ([]string, bool)
```

Pointer receiver on `Garden`. Dereferences `*g` to perform map lookup. Returns the plant slice and whether the child was found.

### NewGarden Constructor

```go
func NewGarden(diagram string, children []string) (*Garden, error)
```

Steps:
1. Split diagram by `\n` - must yield exactly 3 parts with first part empty (diagram starts with `\n`)
2. Validate rows have same length
3. Validate row length equals `2 * len(children)` (each child gets 2 cups per row)
4. Copy children slice to avoid mutating the input, then sort the copy alphabetically
5. Initialize Garden map, check for duplicate names (map size vs slice length)
6. Iterate over both rows, for each child at index `nx`, read positions `2*nx` and `2*nx+1`
7. Map each character (G/C/R/V) to its plant name; return error on invalid codes
8. Return pointer to Garden

### Plant Code Mapping

Use a switch statement:
- 'G' -> "grass"
- 'C' -> "clover"
- 'R' -> "radishes"
- 'V' -> "violets"
- default -> error

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: Kindergarten Garden (Go)

## Verdict: **PASS**

## Independent Test Results

All tests and benchmarks were run independently by the verifier agent.

### Build
```
$ go build ./...
```
Build completed with no errors or warnings.

### Tests
```
$ go test -v ./...
=== RUN   TestGarden
=== RUN   TestGarden/garden_with_single_student        --- PASS
=== RUN   TestGarden/different_garden_with_single_student --- PASS
=== RUN   TestGarden/garden_with_two_students           --- PASS
=== RUN   TestGarden/garden_with_three_students         --- PASS
=== RUN   TestGarden/full_garden                        --- PASS
=== RUN   TestGarden/names_out_of_order                 --- PASS
=== RUN   TestGarden/lookup_invalid_name                --- PASS
=== RUN   TestGarden/wrong_diagram_format               --- PASS
=== RUN   TestGarden/mismatched_rows                    --- PASS
=== RUN   TestGarden/odd_number_of_cups                 --- PASS
=== RUN   TestGarden/duplicate_name                     --- PASS
=== RUN   TestGarden/invalid_cup_codes                  --- PASS
--- PASS: TestGarden (0.00s)
=== RUN   TestNamesNotModified                          --- PASS
=== RUN   TestTwoGardens                                --- PASS
PASS
```

**14/14 tests PASS, 0 FAIL**

### Benchmarks
```
$ go test -bench=. -benchtime=1s
BenchmarkNewGarden-128          97352       13607 ns/op
BenchmarkGarden_Plants-128   11127954         103.5 ns/op
PASS
```

**2/2 benchmarks PASS**

## Acceptance Criteria Checklist

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `NewGarden(diagram, children) (*Garden, error)` | PASS | Line 16: correct signature |
| 2 | `(*Garden).Plants(child) ([]string, bool)` | PASS | Line 11: pointer receiver, correct return type |
| 3 | Children assigned cups in alphabetical order | PASS | Line 29: `sort.Strings(alpha)` on sorted copy; TestGarden/names_out_of_order PASS |
| 4 | Input children slice NOT modified | PASS | Line 28: `append([]string{}, children...)` creates copy; TestNamesNotModified PASS |
| 5 | Multiple Garden instances independent | PASS | `Garden` is `map[string][]string` with no package state; TestTwoGardens PASS |
| 6a | Error: diagram wrong format | PASS | Line 18: checks `rows[0] != ""`; TestGarden/wrong_diagram_format PASS |
| 6b | Error: mismatched rows | PASS | Line 21: checks `len(rows[1]) != len(rows[2])`; TestGarden/mismatched_rows PASS |
| 6c | Error: odd number of cups | PASS | Line 24: checks `len(rows[1]) != 2*len(children)`; TestGarden/odd_number_of_cups PASS |
| 6d | Error: duplicate child names | PASS | Line 33: checks `len(g) != len(alpha)` after map insertion; TestGarden/duplicate_name PASS |
| 6e | Error: invalid plant codes | PASS | Line 49-50: default case in switch returns error; TestGarden/invalid_cup_codes PASS |
| 7 | All tests in kindergarten_garden_test.go pass | PASS | 14/14 PASS |
| 8 | Benchmarks run without error | PASS | BenchmarkNewGarden + BenchmarkGarden_Plants both PASS |

## Key Constraints Verified

- Package name: `kindergarten` - confirmed on line 1
- File: `kindergarten_garden.go` - confirmed
- Go 1.18 module: `go.mod` specifies `go 1.18`
- API matches test expectations: `NewGarden` returns `*Garden`, `Plants` is pointer receiver method
- `Garden` type supports map-like semantics: `type Garden map[string][]string`

## Conclusion

All acceptance criteria from GOAL.md are fully met. The implementation is correct, clean, and all 14 tests plus 2 benchmarks pass. The executor's test results are confirmed independently.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-131](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-131)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
