### PR TITLE
Closes #133: polyglot-go-ledger

### DIFF
--- a/go/exercises/practice/ledger/ledger.go
+++ b/go/exercises/practice/ledger/ledger.go
@@ -1,1 +1,134 @@
 package ledger
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Entry struct {
+	Date        string
+	Description string
+	Change      int
+}
+
+var currencySymbols = map[string]string{
+	"USD": "$",
+	"EUR": "€",
+}
+
+func FormatLedger(currency string, locale string, entries []Entry) (string, error) {
+	symbol, ok := currencySymbols[currency]
+	if !ok {
+		return "", errors.New("invalid currency")
+	}
+
+	if locale != "en-US" && locale != "nl-NL" {
+		return "", errors.New("invalid locale")
+	}
+
+	sorted := make([]Entry, len(entries))
+	copy(sorted, entries)
+
+	for _, e := range sorted {
+		if _, err := time.Parse("2006-01-02", e.Date); err != nil {
+			return "", err
+		}
+	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Date != sorted[j].Date {
+			return sorted[i].Date < sorted[j].Date
+		}
+		if sorted[i].Description != sorted[j].Description {
+			return sorted[i].Description < sorted[j].Description
+		}
+		return sorted[i].Change < sorted[j].Change
+	})
+
+	var b strings.Builder
+
+	if locale == "en-US" {
+		b.WriteString("Date       | Description               | Change\n")
+	} else {
+		b.WriteString("Datum      | Omschrijving              | Verandering\n")
+	}
+
+	for _, e := range sorted {
+		date := formatDate(e.Date, locale)
+		desc := truncateDescription(e.Description)
+		change := formatChange(e.Change, symbol, locale)
+		b.WriteString(fmt.Sprintf("%-10s | %-25s | %13s\n", date, desc, change))
+	}
+
+	return b.String(), nil
+}
+
+func formatDate(date string, locale string) string {
+	t, _ := time.Parse("2006-01-02", date)
+	if locale == "en-US" {
+		return t.Format("01/02/2006")
+	}
+	return t.Format("02-01-2006")
+}
+
+func truncateDescription(desc string) string {
+	if len(desc) > 25 {
+		return desc[:22] + "..."
+	}
+	return desc
+}
+
+func formatChange(cents int, symbol string, locale string) string {
+	negative := cents < 0
+	abs := cents
+	if negative {
+		abs = -abs
+	}
+	units := abs / 100
+	frac := abs % 100
+
+	var thousandsSep, decimalSep string
+	if locale == "en-US" {
+		thousandsSep = ","
+		decimalSep = "."
+	} else {
+		thousandsSep = "."
+		decimalSep = ","
+	}
+
+	unitsStr := formatWithThousands(units, thousandsSep)
+	amount := fmt.Sprintf("%s%s%02d", unitsStr, decimalSep, frac)
+
+	if locale == "en-US" {
+		if negative {
+			return "(" + symbol + amount + ")"
+		}
+		return symbol + amount + " "
+	}
+	if negative {
+		return symbol + " " + amount + "-"
+	}
+	return symbol + " " + amount + " "
+}
+
+func formatWithThousands(n int, sep string) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var result strings.Builder
+	remainder := len(s) % 3
+	if remainder > 0 {
+		result.WriteString(s[:remainder])
+	}
+	for i := remainder; i < len(s); i += 3 {
+		if result.Len() > 0 {
+			result.WriteString(sep)
+		}
+		result.WriteString(s[i : i+3])
+	}
+	return result.String()
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/133

## osmi Post-Mortem: Issue #133 — polyglot-go-ledger

### Plan Summary
# Implementation Plan: polyglot-go-ledger

## File to Modify

- `go/exercises/practice/ledger/ledger.go` — the only file that needs changes

## Architecture

Single file implementation with clean separation of concerns:

### 1. Entry Struct

```go
type Entry struct {
    Date        string // "YYYY-MM-DD"
    Description string
    Change      int    // cents (minor currency units)
}
```

### 2. Locale and Currency Configuration

Use maps to hold locale-specific and currency-specific settings:

- **Currency symbols**: map `"USD"→"$"`, `"EUR"→"€"`
- **Locale headers**: map with literal header strings per locale
- **Locale date formatting**: map with formatting closures or a switch

### 3. FormatLedger Function

```
func FormatLedger(currency string, locale string, entries []Entry) (string, error)
```

Steps:
1. **Validate currency** — lookup in currency symbol map, return error if not found
2. **Validate locale** — check against known locales (`en-US`, `nl-NL`), return error if unknown
3. **Copy entries** — `make([]Entry, len(entries))` + `copy()` to avoid mutating the input
4. **Validate dates** — parse each entry's date with `time.Parse("2006-01-02", ...)`, return error if invalid
5. **Sort entries** — sort by Date string (lexicographic, since YYYY-MM-DD sorts correctly), then Description, then Change (using `sort.Slice` with stable ordering)
6. **Build header** — use literal locale-specific header string + newline
7. **Format each entry** — format date, truncate description, format change amount, build row
8. **Return** — concatenated string via `strings.Builder`

### 4. Helper Functions

- **`formatDate(date string, locale string) string`** — parses "YYYY-MM-DD" and reformats to locale
- **`formatChange(cents int, symbol string, locale string) string`** — formats the monetary amount
- **`truncateDescription(desc string) string`** — truncates/pads to exactly 25 characters


### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report — polyglot-go-ledger (Issue #133)

## Acceptance Criteria Checklist

| # | Criterion | Verdict | Notes |
|---|-----------|---------|-------|
| 1 | **Entry struct** defined with `Date` (string), `Description` (string), `Change` (int) | **PASS** | `ledger.go:11-15` — struct matches spec exactly. |
| 2 | **FormatLedger signature** `(currency, locale string, entries []Entry) (string, error)` | **PASS** | `ledger.go:22` — signature correct. |
| 3 | **Locale support (en-US)**: header, `MM/DD/YYYY`, `.` decimal, `,` thousands, `($X.XX)` negative, `$X.XX ` positive | **PASS** | Header at line 54, date format at line 72, separators at lines 94-96, negative/positive formatting at lines 106-109. All verified by tests (`one_entry`, `credit_and_debit`, `American_negative_number_with_3_digits_before_decimal_point`). |
| 3b | **Locale support (nl-NL)**: header, `DD-MM-YYYY`, `,` decimal, `.` thousands, `$ X,XX-` negative, `$ X,XX ` positive | **PASS** | Header at line 56, date format at line 74, separators at lines 98-99, negative/positive formatting at lines 111-114. Verified by `Dutch_locale` and `Dutch_negative_number_with_3_digits_before_decimal_point` tests. |
| 4 | **Currency support**: `USD` → `$`, `EUR` → `€` | **PASS** | Map at lines 17-20. Verified by `euros` test. |
| 5 | **Sorting**: by date, then description, then change | **PASS** | `sort.Slice` at lines 41-49 implements correct three-key comparison. Verified by `multiple_entries_on_same_date_ordered_by_description` and `final_order_tie_breaker_is_change` tests. |
| 6 | **Description truncation**: >25 chars → 22 chars + `...` | **PASS** | `truncateDescription` at lines 77-81. Verified by `overlong_descriptions` test. |
| 7 | **Error handling**: invalid currency, locale, date | **PASS** | Currency check at lines 23-25, locale check at lines 28-30, date validation at lines 35-38. All 6 failure tests pass. |
| 8 | **Immutability**: does not modify input entries | **PASS** | `copy(sorted, entries)` at lines 32-33 creates independent copy. `TestFormatLedgerNotChangeInput` passes. |
| 9 | **All tests pass**: `go test ./...` | **PASS** | 17/17 tests pass (10 success + 6 failure + 1 immutability). Independently confirmed. |

## Challenger Findings (Advisory)

The challenger identified two edge-case issues:

1. **`math.MinInt` overflow** — negating `math.MinInt` overflows. Not covered by any test and outside the exercise specification (amounts are in cents with realistic values).
2. **UTF-8 mid-rune truncation** — byte-based `desc[:22]` can split multibyte characters. Not tested by the exercise test suite.

Both are valid observations for production code but do **not** affect any acceptance criterion or test case.

## Independent Test Run

```
$ go test -v ./...
--- PASS: TestFormatLedgerSuccess (0.00s)     [10/10 subtests]
--- PASS: TestFormatLedgerFailure (0.00s)     [6/6 subtests]
--- PASS: TestFormatLedgerNotChangeInput (0.00s)
PASS

$ go vet ./...
(clean — no issues)
```

## Overall Verdict

**PASS**

All 9 acceptance criteria are met. All 17 tests pass. The implementation is correct, clean, and idiomatic Go.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-133](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-133)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
