### PR TITLE
Closes #145: polyglot-go-pig-latin

### DIFF
--- a/go/exercises/practice/pig-latin/pig_latin.go
+++ b/go/exercises/practice/pig-latin/pig_latin.go
@@ -1,1 +1,31 @@
 package piglatin
+
+import (
+	"regexp"
+	"strings"
+)
+
+var vowel = regexp.MustCompile(`^([aeiou]|y[^aeiou]|xr)[a-z]*`)
+var containsy = regexp.MustCompile(`^([^aeiou]+)y([a-z]*)`)
+var cons = regexp.MustCompile(`^([^aeiou]?qu|[^aeiou]+)([a-z]*)`)
+
+func Word(s string) (result string) {
+	if m := containsy.FindStringSubmatch(s); m != nil {
+		return "y" + m[2] + m[1] + "ay"
+	}
+	if vowel.MatchString(s) {
+		return s + "ay"
+	}
+	if m := cons.FindStringSubmatch(s); m != nil {
+		return m[2] + m[1] + "ay"
+	}
+	return s
+}
+
+func Sentence(s string) string {
+	words := strings.Fields(s)
+	for i, w := range words {
+		words[i] = Word(strings.ToLower(w))
+	}
+	return strings.Join(words, " ")
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/145

## osmi Post-Mortem: Issue #145 — polyglot-go-pig-latin

### Plan Summary
# Implementation Plan: Pig Latin (Issue #145)

## Overview

Implement the Pig Latin translator in `go/exercises/practice/pig-latin/pig_latin.go`. The solution uses regex-based pattern matching to classify words and apply the appropriate transformation rule.

## File to Modify

- `go/exercises/practice/pig-latin/pig_latin.go` — the only file that needs changes

## Architecture

### Approach: Regex-based pattern matching

Use three compiled regex patterns to classify and transform words:

1. **vowel pattern** — `^([aeiou]|y[^aeiou]|xr)[a-z]*` — matches words starting with a vowel, `xr`, or `yt` (where `yt` is matched by `y` followed by non-vowel)
2. **consonant-y pattern** — `^([^aeiou]+)y([a-z]*)` — matches consonant cluster followed by `y` (Rule 4)
3. **consonant-qu pattern** — `^([^aeiou]?qu|[^aeiou]+)([a-z]*)` — matches consonant clusters including `qu` handling (Rules 2 and 3)

### Functions

1. **`Sentence(s string) string`** (exported) — Splits input on whitespace using `strings.Fields`, translates each word via `Word`, and rejoins with spaces.

2. **`Word(s string) string`** (exported) — Translates a single word:
   - First check Rule 4: if consonant cluster + `y`, move consonants before `y` to end + `"ay"`
   - Then check Rule 1: if starts with vowel/xr/yt pattern, append `"ay"`
   - Otherwise apply Rules 2/3: find consonant cluster (including `qu`), move to end + `"ay"`

### Rationale

- Regex approach is clean and concise for this problem
- Order of checks matters: `y`-as-vowel must be checked before the general consonant rule
- The `cons` regex handles both plain consonant clusters and `qu` patterns in a single expression
- Using `strings.Fields` handles any whitespace splitting naturally
- `strings.ToLower` ensures case normalization (though tests only use lowercase)

## Implementation Steps

1. Add `import` block for `regexp` and `strings`
2. Declare three compiled regex patterns as package-level variables
3. Implement `Word` function with the three-branch logic
4. Implement `Sentence` function that splits, translates, and joins
5. Run `go test` to verify all 22 test cases pass

## Testing

```bash
cd go/exercises/practice/pig-latin && go test -v ./...
```

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: Pig Latin Implementation

## Acceptance Criteria Check

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All 22 test cases pass (`go test ./...` exits 0) | PASS |
| 2 | `Sentence(string) string` function exported from package `piglatin` | PASS |
| 3 | Rule 1: vowel-initial words get "ay" appended | PASS |
| 4 | Rule 1: "xr" and "yt" prefixes treated as vowel starts | PASS |
| 5 | Rule 2: consonant clusters moved to end | PASS |
| 6 | Rule 3: "qu" (with optional preceding consonants) moved to end | PASS |
| 7 | Rule 4: "y" treated as vowel after consonant cluster | PASS |
| 8 | Multi-word phrases handled correctly | PASS |
| 9 | Solution compiles without errors | PASS |
| 10 | No modifications to test files | PASS |

## Evidence

- **Build**: `go build ./...` completed with no errors
- **Tests**: `go test -v ./...` shows 22/22 PASS
- **Vet**: `go vet ./...` clean, no issues
- **Test files**: `cases_test.go` and `pig_latin_test.go` are unmodified (verified via git status)
- **Implementation**: Only `pig_latin.go` was modified, adding 30 lines of code

## Overall Verdict

**PASS**

All acceptance criteria are met. The implementation correctly handles all four pig latin translation rules and passes the complete test suite.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-145](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-145)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
