### PR TITLE
Closes #170: polyglot-go-forth

### DIFF
--- a/go/exercises/practice/forth/forth.go
+++ b/go/exercises/practice/forth/forth.go
@@ -1,1 +1,228 @@
 package forth
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type operatorFn func(stack *[]int) error
+
+type operatorID byte
+
+const (
+	opAdd operatorID = iota
+	opSub
+	opMul
+	opDiv
+	opDup
+	opDrop
+	opSwap
+	opOver
+	opConst
+	opUserDef
+	opEndDef
+)
+
+type operatorTyp struct {
+	fn operatorFn
+	id operatorID
+}
+
+// Forth evaluates a sequence of Forth phrases and returns the resulting stack.
+func Forth(input []string) ([]int, error) {
+	if len(input) == 0 {
+		return []int{}, nil
+	}
+
+	stack := make([]int, 0, 8)
+	userDefs := make(map[string][]operatorTyp, 8)
+
+	for _, phrase := range input {
+		opList, err := parse(phrase, userDefs)
+		if err != nil {
+			return nil, err
+		}
+		for _, opr := range opList {
+			if err := opr.fn(&stack); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return stack, nil
+}
+
+func parse(phrase string, userDefs map[string][]operatorTyp) ([]operatorTyp, error) {
+	words := strings.FieldsFunc(phrase, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	})
+
+	var oplist []operatorTyp
+
+	for t := 0; t < len(words); t++ {
+		w := strings.ToUpper(words[t])
+
+		if udef, ok := userDefs[w]; ok {
+			oplist = append(oplist, udef...)
+		} else if op, ok := builtinOps[w]; ok {
+			if op.id == opUserDef {
+				t++
+				if t >= len(words) {
+					return nil, errEmptyUserDef
+				}
+				userword := strings.ToUpper(words[t])
+				if _, err := strconv.Atoi(userword); err == nil {
+					return nil, errInvalidUserDef
+				}
+				t++
+				var userops []operatorTyp
+				for t < len(words) {
+					oneOp, err := parse(words[t], userDefs)
+					if err != nil {
+						return nil, err
+					}
+					if oneOp[0].id == opEndDef {
+						break
+					}
+					userops = append(userops, oneOp...)
+					t++
+				}
+				if len(userops) == 0 {
+					return nil, errEmptyUserDef
+				}
+				userDefs[userword] = userops
+			} else {
+				oplist = append(oplist, op)
+			}
+		} else {
+			x, err := strconv.Atoi(w)
+			if err != nil {
+				return nil, errUndefinedWord
+			}
+			oplist = append(oplist, operatorTyp{
+				id: opConst,
+				fn: func(stack *[]int) error {
+					push(stack, x)
+					return nil
+				},
+			})
+		}
+	}
+
+	return oplist, nil
+}
+
+var builtinOps = map[string]operatorTyp{
+	"+":    {add, opAdd},
+	"-":    {subtract, opSub},
+	"*":    {multiply, opMul},
+	"/":    {divide, opDiv},
+	"DUP":  {dup, opDup},
+	"DROP": {drop, opDrop},
+	"SWAP": {swap, opSwap},
+	"OVER": {over, opOver},
+	":":    {nil, opUserDef},
+	";":    {nil, opEndDef},
+}
+
+func pop(stack *[]int) (int, error) {
+	n := len(*stack)
+	if n == 0 {
+		return 0, errNotEnoughOperands
+	}
+	v := (*stack)[n-1]
+	*stack = (*stack)[:n-1]
+	return v, nil
+}
+
+func pop2(stack *[]int) (int, int, error) {
+	v1, err := pop(stack)
+	if err != nil {
+		return 0, 0, err
+	}
+	v2, err := pop(stack)
+	return v1, v2, err
+}
+
+func push(stack *[]int, v int) {
+	*stack = append(*stack, v)
+}
+
+func binaryOp(stack *[]int, op func(a, b int) int) error {
+	v1, v2, err := pop2(stack)
+	if err != nil {
+		return err
+	}
+	push(stack, op(v2, v1))
+	return nil
+}
+
+func add(stack *[]int) error {
+	return binaryOp(stack, func(a, b int) int { return a + b })
+}
+
+func subtract(stack *[]int) error {
+	return binaryOp(stack, func(a, b int) int { return a - b })
+}
+
+func multiply(stack *[]int) error {
+	return binaryOp(stack, func(a, b int) int { return a * b })
+}
+
+func divide(stack *[]int) error {
+	v1, v2, err := pop2(stack)
+	if err != nil {
+		return err
+	}
+	if v1 == 0 {
+		return errDivideByZero
+	}
+	push(stack, v2/v1)
+	return nil
+}
+
+func dup(stack *[]int) error {
+	v, err := pop(stack)
+	if err != nil {
+		return err
+	}
+	push(stack, v)
+	push(stack, v)
+	return nil
+}
+
+func drop(stack *[]int) error {
+	_, err := pop(stack)
+	return err
+}
+
+func swap(stack *[]int) error {
+	v1, v2, err := pop2(stack)
+	if err != nil {
+		return err
+	}
+	push(stack, v1)
+	push(stack, v2)
+	return nil
+}
+
+func over(stack *[]int) error {
+	v1, v2, err := pop2(stack)
+	if err != nil {
+		return err
+	}
+	push(stack, v2)
+	push(stack, v1)
+	push(stack, v2)
+	return nil
+}
+
+var (
+	errNotEnoughOperands = errors.New("not enough operands")
+	errDivideByZero      = errors.New("divide by zero")
+	errEmptyUserDef      = errors.New("empty user definition")
+	errInvalidUserDef    = errors.New("illegal operation")
+	errUndefinedWord     = errors.New("undefined operation")
+)


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/170

## osmi Post-Mortem: Issue #170 — polyglot-go-forth

### Plan Summary
# Implementation Plan: Forth Evaluator

## File to Modify

- `go/exercises/practice/forth/forth.go` — the sole implementation file

## Architecture

The solution follows a two-phase approach per phrase: **parse** then **execute**.

### Data Structures

1. **`operatorFn`** — `func(stack *[]int) error` — a function that operates on the stack
2. **`operatorID`** — byte enum identifying operator type (used to detect `:` and `;` during parsing)
3. **`operatorTyp`** — struct combining `fn` and `id`
4. **Stack** — `[]int` slice, manipulated via `push`, `pop`, `pop2` helpers
5. **User definitions** — `map[string][]operatorTyp` mapping uppercased word names to their expanded operator lists

### Core Algorithm

**`Forth(input []string) ([]int, error)`**:
1. Initialize empty stack and user-definitions map
2. For each phrase in input:
   a. Parse the phrase into an operator list (expanding user defs inline, recording new defs)
   b. Execute each operator in the list against the stack
3. Return the stack

**`parse(phrase string, userDefs map[string][]operatorTyp) ([]operatorTyp, error)`**:
1. Split phrase on whitespace
2. For each token:
   - If token matches a user-defined word → expand (append its operator list)
   - If token is a built-in operator → append it
   - If token is `:` → begin user definition:
     - Next token is the word name (must not be a number)
     - Collect tokens until `;`, recursively parsing each one
     - Store the resulting operator list in userDefs (snapshot semantics: uses current defs at definition time)
   - Otherwise → parse as integer literal, create a const-push operator

### Built-in Operations

| Word | Stack Effect | Notes |
|------|-------------|-------|
| `+` | `(a b -- a+b)` | |
| `-` | `(a b -- a-b)` | |
| `*` | `(a b -- a*b)` | |
| `/` | `(a b -- a/b)` | Integer division; error on zero divisor |
| `DUP` | `(a -- a a)` | |
| `DROP` | `(a -- )` | |
| `SWAP` | `(a b -- b a)` | |
| `OVER` | `(a b -- a b a)` | |

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
No verification report found.

### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-170](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-170)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
