### PR TITLE
Closes #209: polyglot-go-error-handling

### DIFF
--- a/.osmi/agents/implementer/changes.md
+++ b/.osmi/agents/implementer/changes.md
@@ -1,0 +1,27 @@
+# Changes Log - Implementer
+
+## 2026-02-16: Implement Use Function
+
+### File Modified
+- `go/exercises/practice/error-handling/error_handling.go`
+
+### Changes Made
+Implemented the `Use` function with comprehensive error handling:
+
+1. **Transient Error Retry Loop**: The function attempts to open a resource using the provided `opener`, retrying on `TransientError` and returning immediately on other errors.
+
+2. **Resource Management**: Uses `defer r.Close()` to ensure the resource is properly closed when the function exits.
+
+3. **Panic Recovery**: Implements a deferred panic recovery mechanism that:
+   - Catches any panics during `r.Frob(input)` execution
+   - If the panic is a `FrobError`, calls `r.Defrob()` with the appropriate defrobTag
+   - Converts the panic value to an error and returns it via the named return value
+
+4. **Normal Execution**: Calls `r.Frob(input)` and returns `nil` if successful.
+
+### Why
+This implementation demonstrates proper Go error handling patterns including:
+- Retry logic for transient failures
+- Resource cleanup with defer
+- Panic recovery and error propagation
+- Type assertions for error handling

--- a/go/exercises/practice/error-handling/error_handling.go
+++ b/go/exercises/practice/error-handling/error_handling.go
@@ -1,1 +1,25 @@
 package erratum
+
+func Use(opener ResourceOpener, input string) (err error) {
+	var r Resource
+	for {
+		r, err = opener()
+		if err == nil {
+			break
+		}
+		if _, ok := err.(TransientError); !ok {
+			return err
+		}
+	}
+	defer r.Close()
+	defer func() {
+		if x := recover(); x != nil {
+			if frobErr, ok := x.(FrobError); ok {
+				r.Defrob(frobErr.defrobTag)
+			}
+			err = x.(error)
+		}
+	}()
+	r.Frob(input)
+	return nil
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/209

## osmi Post-Mortem: Issue #209 — polyglot-go-error-handling

### Plan Summary
# Implementation Plan: polyglot-go-error-handling

## Branch 1: Minimal defer/recover with named return (Simplicity)

**Approach**: Use a named return value `err`, a `for` loop for transient retries, `defer Close()`, and a separate `defer func()` with `recover()` that handles both FrobError and other panics.

**File to modify**: `go/exercises/practice/error-handling/error_handling.go`

**Implementation**:
```go
package erratum

func Use(opener ResourceOpener, input string) (err error) {
    var r Resource
    for {
        r, err = opener()
        if err == nil {
            break
        }
        if _, ok := err.(TransientError); !ok {
            return err
        }
    }
    defer r.Close()
    defer func() {
        if x := recover(); x != nil {
            if frobErr, ok := x.(FrobError); ok {
                r.Defrob(frobErr.defrobTag)
            }
            err = x.(error)
        }
    }()
    r.Frob(input)
    return nil
}
```

**Rationale**: This is the canonical Go solution. Named return `err` allows the deferred recovery function to set the return value. Two defers ensure Close runs after recovery (LIFO order: recovery runs first, then Close). The for loop handles transient retries.

**Evaluation**:
- Feasibility: High - straightforward idiomatic Go
- Risk: Low - well-established pattern
- Alignment: Fully satisfies all 7 acceptance criteria
- Complexity: Minimal - single file, ~20 lines

## Branch 2: Explicit close management without defer for Close (Extensibility)

**Approach**: Use defer only for recover, manage Close explicitly in each code path to give maximum control over ordering.

**Implementation**:

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Acceptance Criteria Verification Report

**Status: ✅ PASS** - All acceptance criteria satisfied

---

## Verification Summary

| # | Acceptance Criterion | Status | Evidence |
|---|----------------------|--------|----------|
| 1 | Happy path: returns nil, Close() called once | ✅ PASS | TestNoErrors passes |
| 2 | Transient error retry: retries until success or non-transient error | ✅ PASS | TestKeepTryOpenOnTransient passes |
| 3 | Non-transient error on open: returns immediately, no retry | ✅ PASS | TestFailOpenOnNonTransient passes |
| 4 | FrobError panic: Defrob() then Close(), return error | ✅ PASS | TestCallDefrobAndCloseOnFrobError passes |
| 5 | Non-FrobError panic: Close() without Defrob(), return error | ✅ PASS | TestCallCloseOnNonFrobError passes |
| 6 | Resource cleanup: Close() called exactly once if resource opened | ✅ PASS | All tests verify Close() count; no leaks detected |
| 7 | All 5 tests pass | ✅ PASS | 5/5 tests pass (0.004s) |

---

## Detailed Verification

### 1. All 5 Tests Pass ✅

```
=== RUN   TestNoErrors
--- PASS: TestNoErrors (0.00s)
=== RUN   TestKeepTryOpenOnTransient
--- PASS: TestKeepTryOpenOnTransient (0.00s)
=== RUN   TestFailOpenOnNonTransient
--- PASS: TestFailOpenOnNonTransient (0.00s)
=== RUN   TestCallDefrobAndCloseOnFrobError
--- PASS: TestCallDefrobAndCloseOnFrobError (0.00s)
=== RUN   TestCallCloseOnNonFrobError
--- PASS: TestCallCloseOnNonFrobError (0.00s)
PASS
ok  	erratum	0.004s
```

**Result**: ✅ All 5 tests passed

### 2. Build Succeeds with No Errors ✅

- Test output shows clean PASS with no errors or warnings
- Build completed in 0.004s (no compile errors)
- Package built as `erratum` (correct package name)

**Result**: ✅ Build successful

### 3. Only error_handling.go Modified ✅

Latest commit (2d721bd) shows modified files:
- `.osmi/agents/implementer/changes.md` (tracking file, not part of solution)
- `go/exercises/practice/error-handling/error_handling.go` (solution file)

No changes to:
- `common.go` (type definitions preserved)
- `error_handling_test.go` (tests unchanged)
- Any other files outside the exercise

**Result**: ✅ Only solution file modified

### 4. Solution in Package erratum ✅

`go/exercises/practice/error-handling/error_handling.go` line 1:
```go
package erratum
```

**Result**: ✅ Correct package

### 5. All 7 Acceptance Criteria from GOAL.md Satisfied ✅

#### Criterion 1: Happy Path
- **Test**: TestNoErrors (lines 25-46)
- **Requirements**: Returns nil, Close() called exactly once
- **Verification**: Test passes, checks `closeCallsCount == 1`
- **Status**: ✅ PASS

#### Criterion 2: Transient Error Retry
- **Test**: TestKeepTryOpenOnTransient (lines 49-70)
- **Requirements**: Retries on TransientError until success or non-transient error
- **Verification**: Test returns TransientError 3 times, then succeeds; Use() succeeds
- **Status**: ✅ PASS

#### Criterion 3: Non-Transient Error on Open
- **Test**: TestFailOpenOnNonTransient (lines 73-89)
- **Requirements**: Returns non-transient error immediately
- **Verification**: Test expects error "too awesome"; Use() returns correct error
- **Status**: ✅ PASS

#### Criterion 4: FrobError Panic Handling
- **Test**: TestCallDefrobAndCloseOnFrobError (lines 93-124)
- **Requirements**:
  - Call Defrob(frobError.defrobTag)
  - Call Close() exactly once
  - Call Close() after Defrob
  - Return FrobError as error
- **Verification**:
  - Test passes (all assertions pass)
  - Test explicitly checks `closeCallsCount == 0` when Defrob called (line 101-102), verifying Defrob called before Close
  - Test verifies `closeCallsCount == 1` at end (line 118-123)
  - Error message correct: "meh"
- **Status**: ✅ PASS

#### Criterion 5: Non-FrobError Panic Handling
- **Test**: TestCallCloseOnNonFrobError (lines 128-153)
- **Requirements**:
  - NOT call Defrob
  - Call Close() exactly once
  - Return panic value as error
- **Verification**:
  - Test passes
  - `defrobCalled` remains false (line 144-145)
  - `closeCallsCount == 1` (line 147-152)
  - Error message correct: "meh"
- **Status**: ✅ PASS

#### Criterion 6: Resource Cleanup Guarantee
- **Tests**: TestNoErrors, TestCallDefrobAndCloseOnFrobError, TestCallCloseOnNonFrobError
- **Requirements**: Close() must be called exactly once if resource was opened
- **Verification**: All tests verify `closeCallsCount == 1`, no double-closes or leaks
- **Status**: ✅ PASS

#### Criterion 7: All 5 Tests Pass
- **Results**: 5/5 tests pass in 0.004s
- **Tests**: TestNoErrors, TestKeepTryOpenOnTransient, TestFailOpenOnNonTransient, TestCallDefrobAndCloseOnFrobError, TestCallCloseOnNonFrobError
- **Status**: ✅ PASS

---

## Implementation Quality

**Code Review Findings**:
- Idiomatic Go pattern (named returns + defer + recover)
- Correct LIFO defer ordering
- Proper type assertions
- No resource leaks
- Minimal and clean (~25 lines)

**Test Coverage**:
- All error scenarios covered
- All resource cleanup paths verified
- All panic scenarios handled
- Ordering constraints validated

---

## Final Verdict

### ✅ **PASS**

All acceptance criteria have been verified and satisfied:
- ✅ All 7 acceptance criteria from GOAL.md met
- ✅ All 5 tests pass
- ✅ Build succeeds with no errors
- ✅ Only error_handling.go modified
- ✅ Solution in package erratum
- ✅ No modifications to supporting files

**The implementation is complete and correct. Ready for merge.**


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-209](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-209)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
