### PR TITLE
Closes #215: polyglot-go-hexadecimal

### DIFF
--- a/go/exercises/practice/hexadecimal/hexadecimal.go
+++ b/go/exercises/practice/hexadecimal/hexadecimal.go
@@ -1,1 +1,64 @@
 package hexadecimal
+
+import (
+	"errors"
+	"math"
+)
+
+var ErrRange = errors.New("value out of range")
+var ErrSyntax = errors.New("invalid syntax")
+
+type ParseError struct {
+	Num string
+	Err error
+}
+
+func (e *ParseError) Error() string {
+	return "hexadecimal.ParseHex: parsing \"" + e.Num + "\": " + e.Err.Error()
+}
+
+func ParseHex(s string) (n int64, err error) {
+	if len(s) < 1 {
+		return 0, &ParseError{s, ErrSyntax}
+	}
+	for i := 0; i < len(s); i++ {
+		d := s[i]
+		var v byte
+		switch {
+		case '0' <= d && d <= '9':
+			v = d - '0'
+		case 'a' <= d && d <= 'f':
+			v = d - 'a' + 10
+		case 'A' <= d && d <= 'F':
+			v = d - 'A' + 10
+		default:
+			return 0, &ParseError{s, ErrSyntax}
+		}
+		if n >= math.MaxInt64/16+1 {
+			return 0, &ParseError{s, ErrRange}
+		}
+		n *= 16
+		n1 := n + int64(v)
+		if n1 < n {
+			return 0, &ParseError{s, ErrRange}
+		}
+		n = n1
+	}
+	return n, nil
+}
+
+func HandleErrors(tests []string) []string {
+	e := make([]string, len(tests))
+	for i, s := range tests {
+		_, err := ParseHex(s)
+		switch pe, ok := err.(*ParseError); {
+		case err == nil:
+			e[i] = "none"
+		case ok && pe.Err == ErrSyntax:
+			e[i] = "syntax"
+		case ok && pe.Err == ErrRange:
+			e[i] = "range"
+		}
+	}
+	return e
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/215

## osmi Post-Mortem: Issue #215 — polyglot-go-hexadecimal

### Plan Summary
# Implementation Plan: polyglot-go-hexadecimal

## Branch 1: Minimal Approach — Direct Character Conversion

**Approach:** Simple loop with a helper function to convert each hex character to its value. Use `fmt.Errorf` for errors with embedded "syntax"/"range" keywords.

**Files to modify:**
- `go/exercises/practice/hexadecimal/hexadecimal.go`

**Design:**
```go
package hexadecimal

import "fmt"

func hexVal(b byte) (int64, bool) {
    switch {
    case '0' <= b && b <= '9': return int64(b - '0'), true
    case 'a' <= b && b <= 'f': return int64(b - 'a' + 10), true
    case 'A' <= b && b <= 'F': return int64(b - 'A' + 10), true
    default: return 0, false
    }
}

func ParseHex(s string) (int64, error) {
    if len(s) == 0 {
        return 0, fmt.Errorf("syntax error: empty string")
    }
    var n int64
    for i := 0; i < len(s); i++ {
        v, ok := hexVal(s[i])
        if !ok {
            return 0, fmt.Errorf("syntax error: invalid char %c", s[i])
        }
        prev := n
        n = n*16 + v
        if n < prev {
            return 0, fmt.Errorf("range error: overflow")
        }
    }
    return n, nil
}

func HandleErrors(tests []string) []string {
    result := make([]string, len(tests))
    for i, s := range tests {
        _, err := ParseHex(s)
        if err == nil {
            result[i] = "none"
        } else if strings.Contains(err.Error(), "syntax") {

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: Hexadecimal to Decimal Converter

## Verdict: **PASS**

---

## 1. Tests Pass (go test exits 0)

**PASS** — Independently ran `go test -v -count=1 ./...`:

```
=== RUN   TestParseHex
--- PASS: TestParseHex (0.00s)
=== RUN   TestHandleErrors
--- PASS: TestHandleErrors (0.00s)
PASS
ok  	hexadecimal	0.004s
```

Both tests pass with exit code 0. No cached results — used `-count=1` to force fresh execution.

## 2. go vet Clean

**PASS** — `go vet ./...` produced no output (clean).

## 3. Acceptance Criteria Checklist

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All tests in `hexadecimal_test.go` pass | PASS |
| 2 | `ParseHex("1")` returns `(1, nil)` | PASS |
| 3 | `ParseHex("10")` returns `(16, nil)` | PASS |
| 4 | `ParseHex("2d")` returns `(45, nil)` | PASS |
| 5 | `ParseHex("012")` returns `(18, nil)` | PASS |
| 6 | `ParseHex("cfcfcf")` returns `(13619151, nil)` | PASS |
| 7 | `ParseHex("CFCFCF")` returns `(13619151, nil)` (case insensitive) | PASS |
| 8 | `ParseHex("")` returns error containing "syntax" | PASS |
| 9 | `ParseHex("peanut")` returns error containing "syntax" | PASS |
| 10 | `ParseHex("2cg134")` returns error containing "syntax" | PASS |
| 11 | `ParseHex("8000000000000000")` returns error containing "range" | PASS |
| 12 | `ParseHex("9223372036854775809")` returns error containing "range" | PASS |
| 13 | `HandleErrors` correctly classifies all test inputs | PASS |
| 14 | No use of `strconv`, `fmt.Sscanf`, or built-in hex parsing | PASS |
| 15 | Solution is in `hexadecimal.go` only (test file not modified) | PASS |

## 4. No Built-in Hex Parsing Functions

**PASS** — Imports are only `errors` and `math`. No `strconv`, `fmt`, or any external packages used. Hex conversion is implemented from first principles using byte arithmetic.

## 5. Challenger Review

**PASS** — The challenger found **no critical issues**. Two minor non-blocking observations were noted:
1. A redundant overflow guard (`n1 < n` check) that is unreachable given the primary guard — harmless dead code.
2. `HandleErrors` has no fallback for unexpected error types — safe given the closed implementation.

Neither affects correctness or test passage.

## 6. Implementation Quality

- Correct hex digit parsing via switch on byte ranges
- Proper overflow detection using `math.MaxInt64/16+1` threshold
- Error types satisfy the `error` interface with appropriate "syntax"/"range" substrings
- `HandleErrors` uses type assertion to correctly classify errors
- Clean, minimal code with only necessary imports

## Summary

All 15 acceptance criteria are satisfied. Tests pass independently. No build errors. No forbidden imports. Challenger found no critical issues. The implementation is correct and complete.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-215](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-215)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
