### PR TITLE
Closes #217: polyglot-go-kindergarten-garden

### DIFF
--- a/go/exercises/practice/kindergarten-garden/kindergarten_garden.go
+++ b/go/exercises/practice/kindergarten-garden/kindergarten_garden.go
@@ -1,1 +1,57 @@
 package kindergarten
+
+import (
+	"errors"
+	"sort"
+	"strings"
+)
+
+type Garden map[string][]string
+
+func (g *Garden) Plants(child string) ([]string, bool) {
+	p, ok := (*g)[child]
+	return p, ok
+}
+
+func NewGarden(diagram string, children []string) (*Garden, error) {
+	rows := strings.Split(diagram, "\n")
+	if len(rows) != 3 || rows[0] != "" {
+		return nil, errors.New("diagram must have two rows")
+	}
+	if len(rows[1]) != len(rows[2]) {
+		return nil, errors.New("diagram rows must be same length")
+	}
+	if len(rows[1]) != 2*len(children) {
+		return nil, errors.New("each diagram row must have two cups per child")
+	}
+	g := Garden{}
+	alpha := append([]string{}, children...)
+	sort.Strings(alpha)
+	for _, n := range alpha {
+		g[n] = make([]string, 0, 4)
+	}
+	if len(g) != len(alpha) {
+		return nil, errors.New("no two children can have the same name")
+	}
+	for _, row := range rows[1:] {
+		for nx, n := range alpha {
+			for cx := range rows[1:] { // a little hack
+				var p string
+				switch row[2*nx+cx] {
+				case 'G':
+					p = "grass"
+				case 'C':
+					p = "clover"
+				case 'R':
+					p = "radishes"
+				case 'V':
+					p = "violets"
+				default:
+					return nil, errors.New("plant codes must be one of G, C, R, or V")
+				}
+				g[n] = append(g[n], p)
+			}
+		}
+	}
+	return &g, nil
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/217

## osmi Post-Mortem: Issue #217 — polyglot-go-kindergarten-garden

### Plan Summary
# Implementation Plan: Kindergarten Garden

## Branch 1: Map-Based (Simple, Minimal)

**Approach**: Use `Garden` as a `map[string][]string` type alias. During construction, validate inputs, sort a copy of children, and populate the map with plant names.

**Files to modify**: `kindergarten_garden.go` (single file)

**Architecture**:
- `type Garden map[string][]string` — simple type alias
- `NewGarden` validates, copies+sorts children, iterates rows and columns to fill the map
- `Plants` does a map lookup and returns `(plants, ok)`

**Implementation**:
```go
package kindergarten

import (
    "errors"
    "sort"
    "strings"
)

type Garden map[string][]string

func (g *Garden) Plants(child string) ([]string, bool) {
    p, ok := (*g)[child]
    return p, ok
}

func NewGarden(diagram string, children []string) (*Garden, error) {
    rows := strings.Split(diagram, "\n")
    if len(rows) != 3 || rows[0] != "" {
        return nil, errors.New("diagram must have two rows")
    }
    if len(rows[1]) != len(rows[2]) {
        return nil, errors.New("diagram rows must be same length")
    }
    if len(rows[1])%2 != 0 || len(rows[1]) != 2*len(children) {
        return nil, errors.New("each diagram row must have two cups per child")
    }
    alpha := append([]string{}, children...)
    sort.Strings(alpha)
    g := Garden{}
    for _, n := range alpha {
        g[n] = make([]string, 0, 4)
    }
    if len(g) != len(alpha) {
        return nil, errors.New("no two children can have the same name")
    }

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Kindergarten Garden Exercise - Verification Report

**Date**: 2026-02-16
**Exercise**: go/exercises/practice/kindergarten-garden
**Verifier**: verifier agent

---

## Verification Summary

**VERDICT: ✅ PASS**

All acceptance criteria have been met. The implementation is correct and ready for deployment.

---

## Detailed Verification

### 1. Test Results Verification

**Status**: ✅ PASS

All tests passed successfully:
- **TestGarden**: 13 subtests all PASS
  - garden_with_single_student ✅
  - different_garden_with_single_student ✅
  - garden_with_two_students ✅
  - garden_with_three_students ✅
  - full_garden ✅
  - names_out_of_order ✅
  - lookup_invalid_name ✅
  - wrong_diagram_format ✅
  - mismatched_rows ✅
  - odd_number_of_cups ✅
  - duplicate_name ✅
  - invalid_cup_codes ✅
- **TestNamesNotModified**: PASS ✅
- **TestTwoGardens**: PASS ✅
- **go vet**: No issues ✅

### 2. Function Signature Verification

**Status**: ✅ PASS

```go
func NewGarden(diagram string, children []string) (*Garden, error)
func (g *Garden) Plants(child string) ([]string, bool)
```

Both functions have correct signatures matching acceptance criteria.

### 3. NewGarden Error Handling Verification

**Status**: ✅ PASS

All required validations are implemented:

| Error Case | Implementation | Status |
|-----------|---|---|
| Wrong diagram format | Lines 18-20: Checks for exactly 3 parts on split, first part empty | ✅ |
| Mismatched row lengths | Lines 21-23: Compares length of row1 and row2 | ✅ |
| Odd number of cups | Lines 24-26: Ensures row length == 2*number of children | ✅ |
| Duplicate child names | Lines 30-35: Compares len(g) to len(alpha) after population | ✅ |
| Invalid plant codes | Lines 40-50: Switch statement validates G, C, R, V only | ✅ |

### 4. Input Mutation Verification

**Status**: ✅ PASS

- **Line 28**: `alpha := append([]string{}, children...)` creates a copy of input
- Input `children` slice is NOT modified before or after sorting
- TestNamesNotModified confirms this requirement is met

### 5. Plants Method Verification

**Status**: ✅ PASS

- Returns 4 plant names as full strings: "grass", "clover", "radishes", "violets"
- Returns `(nil, false)` when child not found
- Correctly maps plant codes to full names (lines 41-48)

### 6. Garden Independence Verification

**Status**: ✅ PASS

- No package-level state: Garden is a type alias for `map[string][]string`
- Each NewGarden call creates a new Garden instance
- TestTwoGardens confirms multiple Garden instances are independent

### 7. Code Quality Verification

**Status**: ✅ PASS

- Package name correct: `kindergarten`
- File name correct: `kindergarten_garden.go`
- No external dependencies
- Clean go vet output

---

## Conclusion

The implementation of the Kindergarten Garden exercise meets all acceptance criteria:

1. ✅ NewGarden validates all error cases correctly
2. ✅ Plants method returns correct plant assignments
3. ✅ Input children slice is not mutated
4. ✅ Multiple Garden instances are independent
5. ✅ All 15 tests pass
6. ✅ No code quality issues

**The exercise is complete and ready for deployment.**


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-217](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-217)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
