### PR TITLE
Closes #278: polyglot-go-book-store

### DIFF
--- a/go/exercises/practice/book-store/book_store.go
+++ b/go/exercises/practice/book-store/book_store.go
@@ -1,1 +1,53 @@
 package bookstore
+
+import "sort"
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Cost calculates the total price (in cents) for a basket of books,
+// applying the best possible discount by grouping different books.
+func Cost(books []int) int {
+	// Count frequency of each book (books are numbered 1-5)
+	freq := make([]int, 5)
+	for _, b := range books {
+		freq[b-1]++
+	}
+
+	// Greedily form groups of distinct books
+	groupCount := [6]int{} // groupCount[size] = number of groups of that size
+	for {
+		sort.Sort(sort.Reverse(sort.IntSlice(freq)))
+		if freq[0] == 0 {
+			break
+		}
+		size := 0
+		for i := 0; i < 5; i++ {
+			if freq[i] > 0 {
+				freq[i]--
+				size++
+			}
+		}
+		groupCount[size]++
+	}
+
+	// Optimize: convert pairs of (5-group + 3-group) into (4-group + 4-group)
+	// because 5*600 + 3*720 = 5160, while 4*640 + 4*640 = 5120 (cheaper)
+	swaps := minInt(groupCount[5], groupCount[3])
+	groupCount[5] -= swaps
+	groupCount[3] -= swaps
+	groupCount[4] += 2 * swaps
+
+	// Price per book (in cents) for each group size
+	price := [6]int{0, 800, 760, 720, 640, 600}
+
+	total := 0
+	for size := 1; size <= 5; size++ {
+		total += groupCount[size] * size * price[size]
+	}
+	return total
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/278

## osmi Post-Mortem: Issue #278 — polyglot-go-book-store

### Plan Summary
# Implementation Plan: Book Store

## Proposal A — Greedy with 5→3 to 4→4 Optimization

**Role: Proponent**

### Approach

Use a greedy algorithm that builds groups from largest to smallest, then applies a post-processing optimization step that converts pairs of (5-group + 3-group) into (4-group + 4-group) since 2×4-group cost (5120) < 5-group + 3-group cost (5160).

### Algorithm

1. Count frequency of each book (books 1-5)
2. Sort frequencies in descending order
3. Greedily form groups: repeatedly take one copy from each non-zero frequency (forming a group of size = number of non-zero frequencies), until all books are allocated
4. Count the resulting group sizes (how many groups of size 5, 4, 3, 2, 1)
5. **Optimization**: While there are groups of size 5 AND groups of size 3, convert one 5-group + one 3-group into two 4-groups
6. Compute total cost using the discount table

### Files to Modify

- `go/exercises/practice/book-store/book_store.go` — implement `Cost` function

### Rationale

This is the classic known-optimal solution for this problem. The greedy approach naturally produces the best groupings, and the only non-obvious optimization is the 5+3 → 4+4 conversion. This approach is O(n) where n is the number of books, highly efficient, and easy to understand.

### Implementation

```go
func Cost(books []int) int {
    // Count frequencies
    freq := make([]int, 6) // index 1-5
    for _, b := range books {
        freq[b]++
    }

    // Sort frequencies descending
    sort.Sort(sort.Reverse(sort.IntSlice(freq[1:])))

    // Greedy grouping: form groups by taking one from each non-zero freq
    var groups []int
    for {
        size := 0
        for i := 1; i <= 5; i++ {
            if freq[i] > 0 {
                freq[i]--
                size++
            }
        }

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report

## Verdict: **PASS**

All acceptance criteria are met. The implementation is correct and complete.

---

## Acceptance Criteria Checklist

- [x] **All 18 test cases pass** — Independently ran `go test -v ./...`; all 18 subtests under `TestCost` passed with 0 failures.
- [x] **Empty basket returns 0** — `TestCost/Empty_basket` passes.
- [x] **Single/duplicate books handled correctly** — `TestCost/Only_a_single_book` and `TestCost/Two_of_the_same_book` pass.
- [x] **Optimal grouping works (two groups of 4 cheaper than 5+3)** — Multiple optimization test cases pass, including:
  - `Two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three`
  - `Two_groups_of_four_is_cheaper_than_groups_of_five_and_three`
  - `Four_groups_of_four_are_cheaper_than_two_groups_each_of_five_and_three`
  - `One_group_of_one_and_two_plus_three_groups_of_four_is_cheaper_than_one_group_of_each_size`
- [x] **`go test ./...` passes with no errors** — Exit code 0, all tests PASS.
- [x] **No test files were modified** — Verified via `git diff`:
  - `book_store_test.go`: no changes
  - `cases_test.go`: no changes
  - `go.mod`: no changes
  - `git diff --name-only HEAD~1` confirms only `book_store.go` was changed

## Implementation Review

The implementation in `book_store.go` uses a greedy-then-optimize approach:

1. **Frequency counting**: Counts occurrences of each book (1-5)
2. **Greedy grouping**: Forms groups of distinct books by repeatedly taking one from each non-zero frequency (sorted descending)
3. **5+3 → 4+4 optimization**: Converts pairs of (group-of-5 + group-of-3) into (two groups-of-4), since `5*600 + 3*720 = 5160 > 4*640 + 4*640 = 5120`
4. **Cost calculation**: Applies price-per-book lookup by group size

The algorithm is correct and handles all edge cases properly.

## Test Execution Output

```
=== RUN   TestCost
--- PASS: TestCost (0.00s)
    --- PASS: TestCost/Only_a_single_book (0.00s)
    --- PASS: TestCost/Two_of_the_same_book (0.00s)
    --- PASS: TestCost/Empty_basket (0.00s)
    --- PASS: TestCost/Two_different_books (0.00s)
    --- PASS: TestCost/Three_different_books (0.00s)
    --- PASS: TestCost/Four_different_books (0.00s)
    --- PASS: TestCost/Five_different_books (0.00s)
    --- PASS: TestCost/Two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three (0.00s)
    --- PASS: TestCost/Two_groups_of_four_is_cheaper_than_groups_of_five_and_three (0.00s)
    --- PASS: TestCost/Group_of_four_plus_group_of_two_is_cheaper_than_two_groups_of_three (0.00s)
    --- PASS: TestCost/Two_each_of_first_four_books_and_one_copy_each_of_rest (0.00s)
    --- PASS: TestCost/Two_copies_of_each_book (0.00s)
    --- PASS: TestCost/Three_copies_of_first_book_and_two_each_of_remaining (0.00s)
    --- PASS: TestCost/Three_each_of_first_two_books_and_two_each_of_remaining_books (0.00s)
    --- PASS: TestCost/Four_groups_of_four_are_cheaper_than_two_groups_each_of_five_and_three (0.00s)
    --- PASS: TestCost/Check_that_groups_of_four_are_created_properly_even_when_there_are_more_groups_of_three_than_groups_of_five (0.00s)
    --- PASS: TestCost/One_group_of_one_and_four_is_cheaper_than_one_group_of_two_and_three (0.00s)
    --- PASS: TestCost/One_group_of_one_and_two_plus_three_groups_of_four_is_cheaper_than_one_group_of_each_size (0.00s)
PASS
ok  	bookstore	0.005s
```


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-278](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-278)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
