### PR TITLE
Closes #293: polyglot-go-error-handling

### DIFF
--- a/.osmi/agents/implementer/changes.md
+++ b/.osmi/agents/implementer/changes.md
@@ -1,0 +1,10 @@
+# Changes
+
+## Implement `Use` function for error-handling exercise
+
+- Added `Use(opener ResourceOpener, input string) (err error)` in `error_handling.go`
+- Retries `opener()` in a loop when `TransientError` is returned; returns immediately on other errors
+- Defers `r.Close()` after successful open
+- Deferred recover handler checks for `FrobError` (calls `r.Defrob`) and propagates panic as error via named return
+- Calls `r.Frob(input)` and returns nil on success
+- All 5 tests pass

--- a/go/exercises/practice/error-handling/error_handling.go
+++ b/go/exercises/practice/error-handling/error_handling.go
@@ -1,1 +1,25 @@
 package erratum
+
+func Use(opener ResourceOpener, input string) (err error) {
+	var r Resource
+	for {
+		r, err = opener()
+		if err == nil {
+			break
+		}
+		if _, ok := err.(TransientError); !ok {
+			return err
+		}
+	}
+	defer r.Close()
+	defer func() {
+		if x := recover(); x != nil {
+			if frobErr, ok := x.(FrobError); ok {
+				r.Defrob(frobErr.defrobTag)
+			}
+			err = x.(error)
+		}
+	}()
+	r.Frob(input)
+	return nil
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/293

## osmi Post-Mortem: Issue #293 — polyglot-go-error-handling

### Plan Summary
# Implementation Plan: polyglot-go-error-handling

## Proposal A

**Role: Proponent**

### Approach: Two-defer pattern with named return values

This approach uses Go's canonical defer/recover pattern with two separate `defer` statements — one for `Close()` and one for panic recovery — and a named return value to propagate errors from the recover handler.

### Files to Modify
- `go/exercises/practice/error-handling/error_handling.go` (only file)

### Implementation

```go
package erratum

func Use(opener ResourceOpener, input string) (err error) {
	var r Resource
	for {
		r, err = opener()
		if err == nil {
			break
		}
		if _, ok := err.(TransientError); !ok {
			return err
		}
	}
	defer r.Close()
	defer func() {
		if x := recover(); x != nil {
			if frobErr, ok := x.(FrobError); ok {
				r.Defrob(frobErr.defrobTag)
			}
			err = x.(error)
		}
	}()
	r.Frob(input)
	return nil
}
```

### Rationale

1. **Retry loop**: An infinite `for` loop calls `opener()` repeatedly. If the error is `nil`, we break. If it's a `TransientError`, we continue looping. Otherwise, we return the error immediately.

2. **Two defers in LIFO order**: `defer r.Close()` is registered first, then the recover handler. Since defers execute LIFO, the recover handler runs first (potentially calling `Defrob`), then `Close` runs. This satisfies the test requirement that `Defrob` is called before `Close`.

3. **Named return value `err`**: The recover handler sets `err` directly via the named return, which is the standard Go pattern for returning errors from deferred functions.

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: error-handling

**Verdict: PASS**

## Checklist

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All 5 tests pass | PASS |
| 2 | `TestNoErrors` — happy path | PASS |
| 3 | `TestKeepTryOpenOnTransient` — retry on transient error | PASS |
| 4 | `TestFailOpenOnNonTransient` — fail on non-transient error | PASS |
| 5 | `TestCallDefrobAndCloseOnFrobError` — defrob + close on FrobError panic | PASS |
| 6 | `TestCallCloseOnNonFrobError` — close only on non-FrobError panic | PASS |
| 7 | Only `error_handling.go` modified (under `go/`) | PASS |
| 8 | Resource always closed exactly once if opened | PASS |
| 9 | `Defrob` called before `Close` on FrobError | PASS |

## Test Output (independent run)

```
=== RUN   TestNoErrors
--- PASS: TestNoErrors (0.00s)
=== RUN   TestKeepTryOpenOnTransient
--- PASS: TestKeepTryOpenOnTransient (0.00s)
=== RUN   TestFailOpenOnNonTransient
--- PASS: TestFailOpenOnNonTransient (0.00s)
=== RUN   TestCallDefrobAndCloseOnFrobError
--- PASS: TestCallDefrobAndCloseOnFrobError (0.00s)
=== RUN   TestCallCloseOnNonFrobError
--- PASS: TestCallCloseOnNonFrobError (0.00s)
PASS
ok  	erratum	0.004s
```

## File Change Verification

Only one exercise file modified: `go/exercises/practice/error-handling/error_handling.go`

```
git diff --name-only HEAD~1 -- go/
go/exercises/practice/error-handling/error_handling.go
```

No changes to `common.go`, test files, or `.meta/`.

## Implementation Review

The `Use` function correctly:
- Retries `opener()` in a loop on `TransientError`, returns immediately on other errors
- Uses `defer r.Close()` to ensure resource is closed exactly once
- Uses `defer func()` with `recover()` to catch panics from `Frob`
- Type-asserts `FrobError` to call `Defrob(defrobTag)` before `Close` (defer ordering)
- Assigns recovered error to named return `err` for proper error propagation


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-293](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-293)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
