### PR TITLE
Closes #305: polyglot-go-markdown

### DIFF
--- a/.osmi/agents/implementer/changes.md
+++ b/.osmi/agents/implementer/changes.md
@@ -1,0 +1,22 @@
+# Changes: Implement Render function for markdown parser
+
+## File Modified
+- `go/exercises/practice/markdown/markdown.go`
+
+## What Was Done
+Implemented the `Render` function that translates markdown input to HTML using a line-by-line processor with inline formatting support.
+
+### Functions Implemented
+1. **`Render(input string) string`** — Main entry point. Splits input into lines, classifies each as header, list item, or paragraph, tracks list state (`<ul>` open/close), applies inline formatting, and returns the built HTML string.
+2. **`headerLevel(line string) int`** — Counts leading `#` characters and returns the level (1-6) if followed by a space, 0 otherwise.
+3. **`applyInline(text string) string`** — Applies bold (`__` → `<strong>`) then italic (`_` → `<em>`) formatting.
+4. **`replaceMarker(text, marker, open, close string) string`** — Generic split-and-rejoin helper that replaces markers with alternating open/close HTML tags.
+
+### Design Decisions
+- Uses `strings.Builder` for efficient string concatenation
+- Processes bold (`__`) before italic (`_`) to prevent marker interference
+- Only imports `"strings"` — no regex or other dependencies
+- Header level 7+ treated as paragraph (per spec)
+
+## Test Results
+All 17 tests pass.

--- a/go/exercises/practice/markdown/markdown.go
+++ b/go/exercises/practice/markdown/markdown.go
@@ -1,1 +1,81 @@
 package markdown
+
+import "strings"
+
+// Render translates markdown input to HTML.
+func Render(input string) string {
+	var result strings.Builder
+	lines := strings.Split(input, "\n")
+	inList := false
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "* ") {
+			if !inList {
+				result.WriteString("<ul>")
+				inList = true
+			}
+			content := applyInline(line[2:])
+			result.WriteString("<li>" + content + "</li>")
+		} else {
+			if inList {
+				result.WriteString("</ul>")
+				inList = false
+			}
+			if strings.HasPrefix(line, "#") {
+				level := headerLevel(line)
+				if level > 0 && level <= 6 {
+					content := applyInline(line[level+1:])
+					lvl := string(rune('0' + level))
+					result.WriteString("<h" + lvl + ">" + content + "</h" + lvl + ">")
+				} else {
+					result.WriteString("<p>" + applyInline(line) + "</p>")
+				}
+			} else {
+				result.WriteString("<p>" + applyInline(line) + "</p>")
+			}
+		}
+	}
+
+	if inList {
+		result.WriteString("</ul>")
+	}
+
+	return result.String()
+}
+
+func headerLevel(line string) int {
+	level := 0
+	for _, c := range line {
+		if c == '#' {
+			level++
+		} else {
+			break
+		}
+	}
+	if level > 0 && level < len(line) && line[level] == ' ' {
+		return level
+	}
+	return 0
+}
+
+func applyInline(text string) string {
+	text = replaceMarker(text, "__", "<strong>", "</strong>")
+	text = replaceMarker(text, "_", "<em>", "</em>")
+	return text
+}
+
+func replaceMarker(text, marker, open, close string) string {
+	parts := strings.Split(text, marker)
+	var result strings.Builder
+	for i, part := range parts {
+		if i > 0 {
+			if i%2 == 1 {
+				result.WriteString(open)
+			} else {
+				result.WriteString(close)
+			}
+		}
+		result.WriteString(part)
+	}
+	return result.String()
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/305

## osmi Post-Mortem: Issue #305 — polyglot-go-markdown

### Plan Summary
# Implementation Plan: polyglot-go-markdown

## Proposal A (Proponent)

### Approach: Line-by-line processor with inline formatting

A single-pass, line-by-line parser. Split input on `\n`, classify each line (header, list item, or paragraph), apply inline formatting (bold/italic), track list state, and build the HTML string.

### Files to modify
- `go/exercises/practice/markdown/markdown.go` — implement `Render` function

### Architecture

```go
func Render(input string) string {
    // 1. Split input into lines
    // 2. For each line, determine type: header, list item, or paragraph
    // 3. Track whether we're inside a <ul> block
    // 4. Apply inline formatting (bold before italic to handle __ vs _)
    // 5. Build result string, closing <ul> when transitioning out of list
}
```

**Key design decisions:**
- Use `strings.Builder` for efficient string concatenation
- Process bold (`__`) before italic (`_`) to avoid `__` being matched as two `_`
- Use `strings.Replace` for inline formatting (simple, no regex needed)
- Count leading `#` characters to determine header level (1-6 valid, 7+ is paragraph)
- Track `inList` boolean to manage `<ul>` open/close tags

### Rationale
- Simple, procedural code that's easy to read and debug
- No regex dependency — just string operations
- Matches the "refactored" style the exercise expects (clean, readable code)
- Single responsibility: line classification, inline formatting, and output building are clearly separated concerns

---

## Proposal B (Opponent)

### Approach: Regex-based parser with token types

Use Go's `regexp` package to classify and transform lines. Define regex patterns for each line type and for inline formatting.

### Files to modify
- `go/exercises/practice/markdown/markdown.go` — implement `Render` function

### Architecture

```go

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: polyglot-go-markdown

## Verdict: PASS

All acceptance criteria are met. The implementation is correct and complete.

## Criteria Checklist

| # | Criterion | Result | Details |
|---|-----------|--------|---------|
| 1 | All 17 test cases pass | PASS | Independently ran `go test -v -count=1 ./...` — all 17 subtests pass |
| 2 | `Render` function signature is `func Render(input string) string` | PASS | Confirmed in `markdown.go:6` |
| 3 | Code is in `package markdown` in `markdown.go` | PASS | Confirmed in `markdown.go:1` |
| 4 | Code compiles without errors | PASS | `go build ./...` and `go vet ./...` both clean |
| 5 | Benchmark test runs without errors | PASS | `go test -bench=.` completes successfully |
| 6 | No test files modified | PASS | `git diff` on `markdown_test.go`, `cases_test.go`, `go.mod` shows no changes |

## Independent Verification Details

- **Test run**: Fresh `go test -v -count=1 ./...` (no cache) — 17/17 PASS in 0.005s
- **Benchmark**: `BenchmarkMarkdown` runs successfully (52209 ns/op)
- **Only standard library**: Implementation uses only `strings` package
- **File modified**: Only `markdown.go` was changed (the solution stub)


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-305](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-305)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
