### PR TITLE
Closes #311: polyglot-go-paasio

### DIFF
--- a/go/exercises/practice/paasio/paasio.go
+++ b/go/exercises/practice/paasio/paasio.go
@@ -1,1 +1,75 @@
 package paasio
+
+import (
+	"io"
+	"sync"
+)
+
+type counter struct {
+	bytes int64
+	ops   int
+	mu    sync.Mutex
+}
+
+func (c *counter) addBytes(n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.bytes += int64(n)
+	c.ops++
+}
+
+func (c *counter) count() (int64, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bytes, c.ops
+}
+
+type readCounter struct {
+	r io.Reader
+	counter
+}
+
+func NewReadCounter(r io.Reader) ReadCounter {
+	return &readCounter{r: r}
+}
+
+func (rc *readCounter) Read(p []byte) (int, error) {
+	n, err := rc.r.Read(p)
+	rc.addBytes(n)
+	return n, err
+}
+
+func (rc *readCounter) ReadCount() (int64, int) {
+	return rc.count()
+}
+
+type writeCounter struct {
+	w io.Writer
+	counter
+}
+
+func NewWriteCounter(w io.Writer) WriteCounter {
+	return &writeCounter{w: w}
+}
+
+func (wc *writeCounter) Write(p []byte) (int, error) {
+	n, err := wc.w.Write(p)
+	wc.addBytes(n)
+	return n, err
+}
+
+func (wc *writeCounter) WriteCount() (int64, int) {
+	return wc.count()
+}
+
+type rwCounter struct {
+	WriteCounter
+	ReadCounter
+}
+
+func NewReadWriteCounter(rw io.ReadWriter) ReadWriteCounter {
+	return &rwCounter{
+		WriteCounter: NewWriteCounter(rw),
+		ReadCounter:  NewReadCounter(rw),
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/311

## osmi Post-Mortem: Issue #311 — polyglot-go-paasio

### Plan Summary
# Implementation Plan: polyglot-go-paasio

## Proposal A: Mutex-based counter with embedded struct

**Role: Proponent**

### Approach

Use a shared `counter` struct with a `sync.Mutex` that tracks bytes and ops. Embed this counter into `readCounter` and `writeCounter` structs. Compose `rwCounter` from `WriteCounter` and `ReadCounter` interfaces.

### File Changes

- **`paasio.go`** — single file, complete implementation.

### Design

```go
package paasio

import (
    "io"
    "sync"
)

type counter struct {
    bytes int64
    ops   int
    mu    sync.Mutex
}

func (c *counter) addBytes(n int) {
    c.mu.Lock()
    defer c.mu.Unlock()
    c.bytes += int64(n)
    c.ops++
}

func (c *counter) count() (int64, int) {
    c.mu.Lock()
    defer c.mu.Unlock()
    return c.bytes, c.ops
}

type readCounter struct {
    r io.Reader
    counter
}

func NewReadCounter(r io.Reader) ReadCounter {
    return &readCounter{r: r}

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report — paasio

## Verdict: PASS

All acceptance criteria have been independently verified.

## Criteria Checklist

### 1. `NewReadCounter(r io.Reader) ReadCounter` — PASS
- Implemented at `paasio.go:32-34`
- `readCounter` struct wraps `io.Reader`, embeds `counter` for tracking
- `Read()` delegates to underlying reader and tracks bytes/ops via `addBytes()`
- `ReadCount()` returns totals via locked `count()` method

### 2. `NewWriteCounter(w io.Writer) WriteCounter` — PASS
- Implemented at `paasio.go:51-53`
- `writeCounter` struct wraps `io.Writer`, embeds `counter` for tracking
- `Write()` delegates to underlying writer and tracks bytes/ops via `addBytes()`
- `WriteCount()` returns totals via locked `count()` method

### 3. `NewReadWriteCounter(rw io.ReadWriter) ReadWriteCounter` — PASS
- Implemented at `paasio.go:70-75`
- `rwCounter` composes `WriteCounter` and `ReadCounter` interfaces
- Delegates to `NewWriteCounter` and `NewReadCounter` internally

### 4. Thread safety with `sync.Mutex` — PASS
- `counter` struct (`paasio.go:8-12`) contains `sync.Mutex`
- `addBytes()` locks before updating both `bytes` and `ops` atomically
- `count()` locks before reading both values
- Bytes and ops are updated under a single lock, satisfying consistency tests

### 5. All tests pass — PASS
- Executor reported: 13/13 tests passed, race detector clean
- **Independent verification**: Ran `go test -cpu 2 -race ./...` — all tests pass, no races detected (2.007s)

### 6. Only `paasio.go` modified — PASS
- `git diff HEAD~1 --name-only` returns only `go/exercises/practice/paasio/paasio.go`
- `git diff HEAD~1 -- interface.go paasio_test.go go.mod` produces no output (files unchanged)

## Implementation Quality Notes

- Clean, minimal implementation with no unnecessary complexity
- Shared `counter` type avoids code duplication between read/write counters
- `rwCounter` uses composition of the existing counters rather than reimplementing
- Proper use of `defer` for mutex unlock ensures no deadlocks on panics


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-311](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-311)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
