### PR TITLE
Closes #315: polyglot-go-pig-latin

### DIFF
--- a/go/exercises/practice/pig-latin/pig_latin.go
+++ b/go/exercises/practice/pig-latin/pig_latin.go
@@ -1,1 +1,38 @@
 package piglatin
+
+import "strings"
+
+var vowels = map[byte]bool{'a': true, 'e': true, 'i': true, 'o': true, 'u': true}
+var specials = map[string]bool{"xr": true, "yt": true}
+var vowelsY = map[byte]bool{'a': true, 'e': true, 'i': true, 'o': true, 'u': true, 'y': true}
+
+// Sentence translates a phrase from English to Pig Latin.
+func Sentence(phrase string) string {
+	words := strings.Fields(phrase)
+	for i, word := range words {
+		words[i] = translateWord(word)
+	}
+	return strings.Join(words, " ")
+}
+
+func translateWord(word string) string {
+	// Rule 1: starts with vowel, "xr", or "yt"
+	if vowels[word[0]] || (len(word) >= 2 && specials[word[:2]]) {
+		return word + "ay"
+	}
+
+	// Scan consonant cluster to find split point
+	// Handles Rule 2 (consonants), Rule 3 (qu), and Rule 4 (y as vowel)
+	for pos := 1; pos < len(word); pos++ {
+		letter := word[pos]
+		if vowelsY[letter] {
+			// Rule 3: if we hit 'u' preceded by 'q', include 'u' in consonant prefix
+			if letter == 'u' && word[pos-1] == 'q' {
+				pos++
+			}
+			return word[pos:] + word[:pos] + "ay"
+		}
+	}
+
+	return word + "ay"
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/315

## osmi Post-Mortem: Issue #315 — polyglot-go-pig-latin

### Plan Summary
# Implementation Plan: Pig Latin Translator

## Proposal A: Map-Based Lookup with Iterative Scanning

**Role: Proponent**

### Approach

Use map-based vowel lookups and iterate through each word character-by-character to determine the split point. This avoids regex and keeps the logic explicit.

### Files to Modify

- `go/exercises/practice/pig-latin/pig_latin.go` — sole file to implement

### Implementation

```go
package piglatin

import "strings"

var vowels = map[byte]bool{'a': true, 'e': true, 'i': true, 'o': true, 'u': true}
var specials = map[string]bool{"xr": true, "yt": true}
var vowelsY = map[byte]bool{'a': true, 'e': true, 'i': true, 'o': true, 'u': true, 'y': true}

func Sentence(phrase string) string {
    words := strings.Fields(phrase)
    for i, word := range words {
        words[i] = pigWord(word)
    }
    return strings.Join(words, " ")
}

func pigWord(word string) string {
    // Rule 1: starts with vowel, "xr", or "yt"
    if vowels[word[0]] || (len(word) >= 2 && specials[word[:2]]) {
        return word + "ay"
    }
    // Rule 4: consonants followed by y (check before Rule 2)
    for i := 1; i < len(word); i++ {
        if word[i] == 'y' {
            return word[i:] + word[:i] + "ay"
        }
        if vowelsY[word[i]] {
            break
        }
    }
    // Rule 3: consonants + "qu"
    // Rule 2: consonants moved to end
    for i := 0; i < len(word); i++ {

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
# Verification Report: Pig Latin Translator

## Verdict: **PASS**

## Criteria Checklist

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | All 22 test cases in `cases_test.go` pass | PASS | Independent `go test -v -count=1 ./...` confirms 22/22 PASS, 0 failures |
| 2 | `Sentence` function is exported from package `piglatin` | PASS | `pig_latin.go` line 1: `package piglatin`; line 10: `func Sentence(phrase string) string` |
| 3 | Multi-word phrases handled correctly | PASS | Test `a_whole_phrase` passes; implementation uses `strings.Fields` to split and `strings.Join` to rejoin |
| 4 | `go test ./...` passes with zero failures | PASS | Independently verified: `ok piglatin 0.005s` |
| 5 | Solution file is `pig_latin.go` in the exercise directory | PASS | File exists at `go/exercises/practice/pig-latin/pig_latin.go` |

## Additional Checks

- **go vet**: Clean, no issues (confirmed by executor logs)
- **Function signature**: `func Sentence(phrase string) string` matches required signature `func Sentence(s string) string`
- **Package name**: `piglatin` - correct
- **Implementation correctness**: Handles all four Pig Latin rules (vowel start, consonant start, consonant+qu, consonant+y)

## Independent Test Run Output

```
=== RUN   TestPigLatin
--- PASS: TestPigLatin (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_a (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_e (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_i (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_o (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_u (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_a_vowel_and_followed_by_a_qu (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_p (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_k (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_x (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_q_without_a_following_u (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_ch (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_qu (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_qu_and_a_preceding_consonant (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_th (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_thr (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_sch (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_yt (0.00s)
    --- PASS: TestPigLatin/word_beginning_with_xr (0.00s)
    --- PASS: TestPigLatin/y_is_treated_like_a_consonant_at_the_beginning_of_a_word (0.00s)
    --- PASS: TestPigLatin/y_is_treated_like_a_vowel_at_the_end_of_a_consonant_cluster (0.00s)
    --- PASS: TestPigLatin/y_as_second_letter_in_two_letter_word (0.00s)
    --- PASS: TestPigLatin/a_whole_phrase (0.00s)
PASS
ok  	piglatin	0.005s
```

## Conclusion

All 5 acceptance criteria are met. The implementation is correct, clean, and passes all tests. **PASS**.


### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-315](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-315)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
