### PR TITLE
Closes #323: polyglot-go-bottle-song

### DIFF
--- a/go/exercises/practice/bottle-song/bottle_song.go
+++ b/go/exercises/practice/bottle-song/bottle_song.go
@@ -1,1 +1,45 @@
 package bottlesong
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+)
+
+var numberWord = []string{
+	"no", "one", "two", "three", "four",
+	"five", "six", "seven", "eight", "nine", "ten",
+}
+
+func capitalize(s string) string {
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		return s
+	}
+	return string(unicode.ToUpper(r)) + s[size:]
+}
+
+func bottleStr(n int) string {
+	if n == 1 {
+		return "bottle"
+	}
+	return "bottles"
+}
+
+func Recite(startBottles int, takeDown int) []string {
+	var result []string
+	for i := startBottles; i > startBottles-takeDown; i-- {
+		if len(result) > 0 {
+			result = append(result, "")
+		}
+		cur := capitalize(numberWord[i])
+		next := numberWord[i-1]
+		result = append(result,
+			fmt.Sprintf("%s green %s hanging on the wall,", cur, bottleStr(i)),
+			fmt.Sprintf("%s green %s hanging on the wall,", cur, bottleStr(i)),
+			"And if one green bottle should accidentally fall,",
+			fmt.Sprintf("There'll be %s green %s hanging on the wall.", next, bottleStr(i-1)),
+		)
+	}
+	return result
+}


### PR DESCRIPTION
Resolves https://github.com/cchuter/polyglot-benchmark/issues/323

## osmi Post-Mortem: Issue #323 — polyglot-go-bottle-song

### Plan Summary
# Implementation Plan: Bottle Song

## Proposal A: Lookup Table with Format Strings

**Role: Proponent**

### Approach

Use a simple lookup table (slice or map) mapping integers 0-10 to their English word equivalents, then build verses using `fmt.Sprintf`.

### Files to Modify

- `go/exercises/practice/bottle-song/bottle_song.go` — add the `Recite` function and helper utilities

### Implementation Details

1. Define a `numberWords` slice: `[]string{"no", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"}`
2. Create a helper `bottlePhrase(n int) string` that returns `"{Word} green bottle(s)"` with correct capitalization and pluralization
3. Implement `Recite(startBottles, takeDown int) []string`:
   - Loop from `startBottles` down for `takeDown` iterations
   - For each verse, append 4 lines to the result slice
   - Between verses, append an empty string `""`
4. Use `strings.Title` (or manual capitalization) for the first line of each verse where the number word needs title case

### Rationale

- Straightforward and minimal code
- Easy to verify correctness by inspecting the lookup table
- No complex logic; the number range is fixed (0-10)
- Follows the pattern seen in beer-song where each verse is constructed independently

---

## Proposal B: Recursive Verse Builder

**Role: Opponent**

### Approach

Build a single `verse(n int) []string` function that returns one verse, then recursively chain verses together.

### Files to Modify

- `go/exercises/practice/bottle-song/bottle_song.go` — add `Recite` and recursive helpers

### Implementation Details

1. Define a map `var words = map[int]string{0: "no", 1: "one", ...}`
2. Create `verse(n int) []string` returning the 4 lines for a single verse
3. Implement `Recite` recursively:

### Iteration Summary
- Iterations: 1
- Final phase: done

### Verification Verdict
No verification report found.

### Archive
Browse the full `.osmi/` artifact tree: [osmi-archive/issue-323](https://github.com/cchuter/polyglot-benchmark/tree/osmi-archive/issue-323)

---
*Autonomously implemented by [osmi](https://github.com/cchuter/osmi).*
